### PR TITLE
Restructure Nablarch documentation into v6/v5 directories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,11 +36,34 @@ nabledge-dev/
 ├── .lw/
 │   ├── research/                  # Research & design documents
 │   └── nab-official/              # Nablarch official documentation (cloned)
+│       ├── v6/                    # Version 6 documentation (main branch)
+│       └── v5/                    # Version 5 documentation (v5-main branch)
 │
 ├── work/                          # Work logs (daily)
 │
 └── CLAUDE.md                      # This file
 ```
+
+---
+
+## Nablarch Official Documentation
+
+The `.lw/nab-official/` directory contains cloned Nablarch official repositories for reference when creating knowledge files.
+
+### Repository Versions
+
+| Repository | v6 | v5 | Notes |
+|------------|----|----|-------|
+| **nablarch-document** | ✓ (main) | ✓ (v5-main) | Official framework documentation |
+| **nablarch-single-module-archetype** | ✓ (main) | ✓ (v5-main) | Maven archetype for single-module projects |
+| **nablarch-system-development-guide** | ✓ (main) | - | System development guide (latest/v6 only) |
+
+### Note for nabledge-5 Development
+
+When creating knowledge files for **nabledge-5**, use the following sources:
+- **Framework docs**: Use `.lw/nab-official/v5/nablarch-document/` (v5-specific)
+- **Archetype**: Use `.lw/nab-official/v5/nablarch-single-module-archetype/` (v5-specific)
+- **Development guide**: Reference `.lw/nab-official/v6/nablarch-system-development-guide/` (no v5 version exists; v6 guide applies)
 
 ---
 

--- a/setup.sh
+++ b/setup.sh
@@ -272,32 +272,37 @@ fi
 # Clone Nablarch official repositories
 print_header "9. Cloning Nablarch Official Repositories"
 
-NAB_OFFICIAL_DIR=".lw/nab-official"
+NAB_OFFICIAL_V6_DIR=".lw/nab-official/v6"
+NAB_OFFICIAL_V5_DIR=".lw/nab-official/v5"
 
-# Create directory if it doesn't exist
-if [ ! -d "$NAB_OFFICIAL_DIR" ]; then
-    print_status info "Creating $NAB_OFFICIAL_DIR directory..."
-    mkdir -p "$NAB_OFFICIAL_DIR"
-    print_status ok "Directory created"
-fi
+# Create directories
+for dir in "$NAB_OFFICIAL_V6_DIR" "$NAB_OFFICIAL_V5_DIR" ".lw/research"; do
+    if [ ! -d "$dir" ]; then
+        print_status info "Creating $dir directory..."
+        mkdir -p "$dir"
+        print_status ok "Directory created"
+    fi
+done
 
-# Function to clone or update repository
+# Enhanced clone_or_update_repo function with branch support
 clone_or_update_repo() {
     local repo_url="$1"
+    local target_dir="$2"
+    local branch="${3:-main}"  # Default to main if not specified
     local repo_name=$(basename "$repo_url" .git)
-    local repo_path="$NAB_OFFICIAL_DIR/$repo_name"
+    local repo_path="$target_dir/$repo_name"
 
     if [ -d "$repo_path" ]; then
         print_status info "Repository $repo_name already exists, updating..."
-        if git -C "$repo_path" pull; then
-            print_status ok "$repo_name updated"
+        if git -C "$repo_path" checkout "$branch" && git -C "$repo_path" pull; then
+            print_status ok "$repo_name updated (branch: $branch)"
         else
             print_status warning "Failed to update $repo_name"
         fi
     else
-        print_status info "Cloning $repo_name..."
-        if git clone "$repo_url" "$repo_path"; then
-            print_status ok "$repo_name cloned"
+        print_status info "Cloning $repo_name (branch: $branch)..."
+        if git clone -b "$branch" "$repo_url" "$repo_path"; then
+            print_status ok "$repo_name cloned (branch: $branch)"
         else
             print_status error "Failed to clone $repo_name"
             exit 1
@@ -305,10 +310,17 @@ clone_or_update_repo() {
     fi
 }
 
-# Clone repositories
-clone_or_update_repo "https://github.com/nablarch/nablarch-document.git"
-clone_or_update_repo "https://github.com/nablarch/nablarch-single-module-archetype.git"
-clone_or_update_repo "https://github.com/Fintan-contents/nablarch-system-development-guide.git"
+# Clone Nablarch 6 repositories (main branch)
+print_status info "Setting up Nablarch 6 repositories..."
+clone_or_update_repo "https://github.com/nablarch/nablarch-document.git" "$NAB_OFFICIAL_V6_DIR" "main"
+clone_or_update_repo "https://github.com/nablarch/nablarch-single-module-archetype.git" "$NAB_OFFICIAL_V6_DIR" "main"
+clone_or_update_repo "https://github.com/Fintan-contents/nablarch-system-development-guide.git" "$NAB_OFFICIAL_V6_DIR" "main"
+
+# Clone Nablarch 5 repositories (v5-main branch)
+print_status info "Setting up Nablarch 5 repositories..."
+clone_or_update_repo "https://github.com/nablarch/nablarch-document.git" "$NAB_OFFICIAL_V5_DIR" "v5-main"
+clone_or_update_repo "https://github.com/nablarch/nablarch-single-module-archetype.git" "$NAB_OFFICIAL_V5_DIR" "v5-main"
+# Note: nablarch-system-development-guide not cloned for v5 (no v5 version exists)
 
 # Final summary
 print_header "Setup Completed Successfully!"

--- a/work/20260212/restructure-nab-official-layout.md
+++ b/work/20260212/restructure-nab-official-layout.md
@@ -1,0 +1,64 @@
+# Restructure Nablarch Official Documentation Layout
+
+## What Was Done
+
+Separated Nablarch official documentation into version-specific directories to enable parallel development of nabledge-6 and nabledge-5 skills.
+
+### Files Changed
+
+1. **setup.sh** (lines 272-311)
+   - Added `NAB_OFFICIAL_V6_DIR` and `NAB_OFFICIAL_V5_DIR` variables
+   - Enhanced `clone_or_update_repo()` function to accept branch parameter
+   - Clone v6 repositories (main branch) to `.lw/nab-official/v6/`
+   - Clone v5 repositories (v5-main branch) to `.lw/nab-official/v5/`
+   - Skip nablarch-system-development-guide for v5 (no v5-main branch exists)
+   - Added `.lw/research/` directory creation
+
+2. **CLAUDE.md** (lines 29-45)
+   - Updated directory structure diagram to show v6/ and v5/ subdirectories
+   - Added new section "Nablarch Official Documentation" with:
+     - Repository version table
+     - Note for nabledge-5 development about which sources to use
+
+### Directory Structure
+
+```
+.lw/nab-official/
+├── v6/
+│   ├── nablarch-document/ (main branch)
+│   ├── nablarch-single-module-archetype/ (main branch)
+│   └── nablarch-system-development-guide/ (main branch)
+└── v5/
+    ├── nablarch-document/ (v5-main branch)
+    └── nablarch-single-module-archetype/ (v5-main branch)
+```
+
+## Results
+
+Changes completed successfully. The setup script now:
+- Clones Nablarch 6 documentation (main branch) into v6/ directory
+- Clones Nablarch 5 documentation (v5-main branch) into v5/ directory
+- Avoids branch switching confusion when working across versions
+
+## Verification Steps
+
+To test the changes:
+
+```bash
+# Run setup script
+./setup.sh
+
+# Verify directory structure
+ls -la .lw/nab-official/v6/
+ls -la .lw/nab-official/v5/
+
+# Verify branches
+git -C .lw/nab-official/v6/nablarch-document branch --show-current  # Should show: main
+git -C .lw/nab-official/v5/nablarch-document branch --show-current  # Should show: v5-main
+```
+
+## Notes
+
+- The `.lw/` directory is in `.gitignore` and remains local-only
+- Zero runtime impact - nabledge skills use `knowledge/*.json` files, not cloned repositories
+- Cloned repositories serve as source material for creating knowledge files during development


### PR DESCRIPTION
## Summary
- Separate Nablarch official documentation into version-specific directories (v6/ and v5/)
- Enable parallel development of nabledge-6 and nabledge-5 skills without branch switching
- Update setup.sh to clone repositories with correct branches
- Update CLAUDE.md documentation with repository version table

## Changes
- **setup.sh**: Enhanced clone function to support branch parameter, clones v6 repos (main) and v5 repos (v5-main)
- **CLAUDE.md**: Added Nablarch Official Documentation section with version details
- **work log**: Created restructure-nab-official-layout.md documenting the changes

## Test plan
- [x] Run setup.sh successfully
- [x] Verify v6/ contains 3 repos on main branch
- [x] Verify v5/ contains 2 repos on v5-main branch
- [x] Confirm branches are correct using git commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)