### PR TITLE
Fix nabledge-6 plugin recognition issue by switching to direct skill copy method

### DIFF
--- a/.claude/skills/git/workflows/branch-create.md
+++ b/.claude/skills/git/workflows/branch-create.md
@@ -133,20 +133,41 @@ fi
 echo "Issue #${issue_number} confirmed"
 ```
 
-**2.3 Generate Branch Name**
+**2.3 Ask for Descriptive Name**
 
-Branch name is always: `issue-${issue_number}`
+Use the AskUserQuestion tool to prompt the user:
+- Question: "Enter a short description for this branch (use lowercase English words separated by hyphens)"
+- Provide one example option: "Example: plugin-first-startup-recognition"
+- User will provide descriptive text via text input
 
-Example:
-- Issue #42 → Branch: `issue-42`
-- Issue #123 → Branch: `issue-123`
+Validate the descriptive name:
 
 ```bash
-branch_name="issue-${issue_number}"
+if ! [[ "$descriptive_name" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+  echo "Error: Branch description must contain only lowercase letters, numbers, and hyphens"
+  echo "Valid examples:"
+  echo "  - add-validation"
+  echo "  - fix-bug-123"
+  echo "  - update-docs"
+  exit 1
+fi
+echo "Descriptive name validated: ${descriptive_name}"
+```
+
+**2.4 Generate Branch Name**
+
+Branch name format: `${issue_number}-${descriptive_name}`
+
+Example:
+- Issue #42, description "add-validation" → Branch: `42-add-validation`
+- Issue #27, description "plugin-first-startup-recognition" → Branch: `27-plugin-first-startup-recognition`
+
+```bash
+branch_name="${issue_number}-${descriptive_name}"
 echo "Branch name will be: ${branch_name}"
 ```
 
-**2.4 Check for Duplicates**
+**2.5 Check for Duplicates**
 
 ```bash
 if git branch --list "${branch_name}" | grep -q .; then
@@ -200,7 +221,7 @@ Use `/git commit` to commit changes.
 
 1. **No emojis**: Never use emojis unless explicitly requested by user
 2. **Issue-driven development**: All branches must be linked to a GitHub issue
-3. **Branch naming**: Always use `issue-<number>` format for consistency
+3. **Branch naming**: Always use `<number>-<descriptive-name>` format (e.g., `27-plugin-first-startup-recognition`) for clarity
 4. **Safety**: Protect main/develop branches, check duplicates, verify clean working tree
 5. **Issue validation**: Always verify issue exists before creating branch
 6. **Branch strategy**: Branches are created from `develop`, not `main`


### PR DESCRIPTION
## Issue

Resolves #27

## Background

Claude Code has a race condition issue where the nabledge-6 plugin is not recognized as a skill on first startup. The issue occurs because:

1. Claude Code uses two-layer storage:
   - Project level: `.claude/settings.json` (controls `/plugin` command visibility)
   - User level: `~/.claude/plugins/` (contains actual skill files needed by skill system)

2. Marketplace data fetching (asynchronous) completes after skill loading (synchronous), causing first-launch failures

3. The upstream issue is closed and unlikely to be fixed

4. Using settings.json for team sharing spreads the problem to all team members

## Solution

Switch from Claude Code's plugin mechanism to direct skill copy method (same as GitHub Copilot):

- Remove marketplace configuration from settings.json
- Copy skill files directly to `.claude/skills/nabledge-6/`
- Claude Code automatically recognizes skills in `.claude/skills/` without additional configuration

## Changes

### Files to Modify

**Scripts:**
- [ ] `scripts/setup-6-cc.sh` - Change from settings.json configuration to direct skill copy
  - Remove jq-based settings.json manipulation
  - Add git sparse-checkout to download skill files
  - Remove VS Code settings configuration (not needed for CC)
  - Keep jq installation (required by nabledge-6 skill itself)

**Documentation:**
- [ ] `.claude/skills/nabledge-6/plugin/GUIDE-CC.md` - Update installation and team sharing instructions
  - Remove settings.json references
  - Update to direct `.claude/skills/` copy approach
  - Clarify that no restart is needed (CC auto-recognizes)
  - Keep jq installation note

### CC vs GHC Differences

After this change, both scripts will download and copy skills directly, but with these intentional differences:

| Aspect | CC (setup-6-cc.sh) | GHC (setup-6-ghc.sh) |
|--------|-------------------|---------------------|
| Skill copy | ✓ Yes (same) | ✓ Yes (same) |
| VS Code settings | ✗ Not needed | ✓ Required (chat.useAgentSkills) |
| Team sharing files | `.claude/skills/` only | `.claude/skills/` + `.vscode/settings.json` |
| Restart required | ✗ No (auto-recognized) | ✓ Yes (VS Code reload) |
| jq installation | ✓ Yes (skill dependency) | ✓ Yes (skill dependency) |

## Testing

- [ ] Run setup-6-cc.sh in clean project
- [ ] Verify `.claude/skills/nabledge-6/` is created
- [ ] Verify `/nabledge-6` command works without restart
- [ ] Verify settings.json is NOT modified
- [ ] Compare with GHC version to confirm intentional differences only

## Documentation Review

- [ ] GUIDE-CC.md accurately describes new installation flow
- [ ] No references to settings.json or plugin installation remain
- [ ] Team sharing instructions are clear and correct