### PR TITLE
Separate development and release workflows

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -3,9 +3,21 @@
 **File**: `.claude/skills/nabledge-6/plugin/CHANGELOG.md`
 **Format**: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## Repository Responsibilities
+
+**nabledge-dev** (this repository):
+- Maintain `[Unreleased]` section only
+- Document changes as they are developed
+- Changes sync to nablarch/nabledge:develop automatically
+
+**nablarch/nabledge**:
+- Manage version sections (0.1, 0.2, etc.)
+- Move [Unreleased] to versioned sections during release
+- Create version tags and releases
+
 ## Scope
 
-Document only changes to **deployed content** (pushed to nablarch/nabledge):
+Document only changes to **deployed content** (synced to nablarch/nabledge):
 
 **Include:**
 - Plugin content (`.claude/skills/nabledge-6/`)
@@ -18,6 +30,16 @@ Document only changes to **deployed content** (pushed to nablarch/nabledge):
 - Development tools, tests, work logs (`work/`)
 - Repository infrastructure (`.claude/rules/`, `setup.sh`)
 
-## Initial Release Note
+## Development Workflow (nabledge-dev)
 
-For version 0.1, omit the `[Unreleased]` section. Add it only when development continues post-release.
+1. Add changes to `[Unreleased]` section as you develop
+2. Use appropriate category: Added, Changed, Deprecated, Removed, Fixed, Security
+3. Changes automatically sync to nablarch/nabledge:develop on merge to main
+
+## Release Workflow (nablarch/nabledge)
+
+Version management happens in nablarch/nabledge repository:
+1. Move [Unreleased] content to new version section with date
+2. Update version in metadata files
+3. Create release PR from develop to main
+4. Tag and release after merge

--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -1,6 +1,30 @@
 # Release Process
 
-## Version Format
+## Repository Responsibilities
+
+**nabledge-dev** (this repository):
+- Development of nabledge skills
+- Automatic sync to `nablarch/nabledge:develop` on push to `main`
+- No version management or tagging
+
+**nablarch/nabledge**:
+- Distribution repository for end users
+- `develop` branch: Latest development state (auto-synced from nabledge-dev)
+- `main` branch: Stable releases
+- Version management, tagging, and release workflow
+
+## Development Workflow (nabledge-dev)
+
+1. Work on feature branches from `main`
+2. Create PR and merge to `main` after review
+3. Changes automatically sync to `nablarch/nabledge:develop`
+4. Users can test unreleased features from develop branch
+
+## Release Workflow (nablarch/nabledge)
+
+Releases are managed in the **nablarch/nabledge** repository, not here.
+
+### Version Format
 
 Skill name includes major version (nabledge-6 = 6.x.x). Version format: **MINOR.PATCH** (e.g., 0.1, 0.2, 0.1.1)
 
@@ -8,9 +32,9 @@ Skill name includes major version (nabledge-6 = 6.x.x). Version format: **MINOR.
 - **PATCH**: Fixes and improvements only
 - **User approval required** - AI suggests, user decides final version
 
-## Release Checklist
+### Release Checklist (in nablarch/nabledge)
 
-1. **Analyze changes** - Read `.claude/skills/nabledge-6/plugin/CHANGELOG.md` [Unreleased] section
+1. **Analyze changes** - Review commits on `develop` branch since last release
 2. **Propose version** - Ask user for version approval based on change type
 3. **Update CHANGELOGs**:
    - `.claude/skills/nabledge-6/plugin/CHANGELOG.md` - Move [Unreleased] to versioned section with date
@@ -18,8 +42,9 @@ Skill name includes major version (nabledge-6 = 6.x.x). Version format: **MINOR.
 4. **Update metadata**:
    - `.claude/skills/nabledge-6/plugin/plugin.json` - Set version field
    - `.claude/marketplace/.claude-plugin/marketplace.json` - Set metadata.version field
-5. **Commit and push** - Stage all 4 files, commit with release message, push to main
+5. **Create release PR** - From `develop` to `main` with all updates
+6. **Tag and release** - After merge, create Git tag and GitHub release
 
-## Multiple Skills
+### Multiple Skills
 
 If both nabledge-6 and nabledge-5 changed, marketplace version = highest skill version (compare MINOR first, then PATCH).

--- a/.github/workflows/sync-to-nabledge.yml
+++ b/.github/workflows/sync-to-nabledge.yml
@@ -3,7 +3,7 @@ name: Sync to nabledge repository
 on:
   push:
     branches:
-      - release
+      - main
 
 jobs:
   sync:
@@ -15,14 +15,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate version updates
-        run: .github/scripts/validate-version-updates.sh
-
       - name: Checkout nabledge repository
         uses: actions/checkout@v4
         with:
           repository: nablarch/nabledge
-          ref: main
+          ref: develop
           token: ${{ secrets.NABLEDGE_SYNC_TOKEN }}
           path: nabledge-repo
 
@@ -44,10 +41,4 @@ jobs:
           ../.github/scripts/commit-and-push.sh \
             "Sync nabledge marketplace from nabledge-dev" \
             "Triggered by: ${TRIGGER_COMMIT_URL}" \
-            "main"
-
-      - name: Create and push version tag
-        working-directory: nabledge-repo
-        run: |
-          VERSION=$(jq -r '.metadata.version' .claude-plugin/marketplace.json)
-          ../.github/scripts/create-version-tag.sh "$VERSION"
+            "develop"

--- a/README.md
+++ b/README.md
@@ -38,46 +38,39 @@ claude
 
 ## Branch Strategy
 
-This repository uses a two-branch strategy for controlled releases:
+This repository uses a single-branch development workflow:
 
 | Branch | Purpose | Workflow |
 |--------|---------|----------|
-| **main** | Development branch | All development work is merged here via pull requests |
-| **release** | Release branch | Receives merges from main when ready to release. Triggers automatic deployment to [nablarch/nabledge](https://github.com/nablarch/nabledge) |
+| **main** | Development branch | All development work is merged here via pull requests. Changes automatically sync to [nablarch/nabledge:develop](https://github.com/nablarch/nabledge/tree/develop) |
 
-### Deployment Flow
+### Development Flow
 
 ```
-Development → main (via PR) → release (manual merge) → nablarch/nabledge (auto-deploy)
+Feature branch → main (via PR) → nablarch/nabledge:develop (auto-sync)
 ```
 
-When changes are pushed to the `release` branch, GitHub Actions automatically:
+When changes are pushed to the `main` branch, GitHub Actions automatically:
 1. Transforms the skill content to marketplace plugin structure
-2. Deploys to the `main` branch in [nablarch/nabledge](https://github.com/nablarch/nabledge)
-3. Creates version tags
+2. Syncs to the `develop` branch in [nablarch/nabledge](https://github.com/nablarch/nabledge)
 
-This allows maintainers to control release timing by deciding when to merge main → release.
+This allows:
+- Continuous integration of development work to nabledge:develop
+- Users can test unreleased features from the develop branch
+- Clear separation: nabledge-dev for development, nabledge for distribution
 
 ### Release Procedure
 
-To release a new version to [nablarch/nabledge](https://github.com/nablarch/nabledge):
+Releases are managed in the **[nablarch/nabledge](https://github.com/nablarch/nabledge)** repository, not here.
 
-1. **Ask Claude Code to prepare release** - Claude Code will follow `.claude/rules/release.md` to update version files and create a PR
+**In nablarch/nabledge repository:**
 
-2. **Merge the release PR to main**
+1. **Prepare release** - Update version files and CHANGELOG in develop branch
+2. **Create release PR** - From `develop` to `main` branch
+3. **Merge and tag** - After review, merge PR and create version tag
+4. **Publish release** - Create GitHub release with release notes
 
-3. **Merge main to release and push**:
-   ```bash
-   git checkout release
-   git merge --ff-only origin/main
-   git push origin release
-   ```
-
-4. GitHub Actions will automatically:
-   - Validate version consistency (marketplace.json = CHANGELOG.md)
-   - Validate version increment (new version > latest tag in nablarch/nabledge)
-   - Deploy to nablarch/nabledge
-   - Create version tag
+See `.claude/rules/release.md` for detailed release workflow.
 
 ## Development
 


### PR DESCRIPTION
Resolves #36

## Summary

This PR separates development workflow from release workflow:

- Development continues in `nabledge-dev:main`
- Changes automatically sync to `nablarch/nabledge:develop`
- Releases are managed in `nablarch/nabledge` repository

## Changes

### Workflow Changes
- Changed GitHub Actions trigger from `release` branch to `main` branch
- Changed sync target from `nablarch/nabledge:main` to `nablarch/nabledge:develop`
- Removed version validation step (was validating version increment)
- Removed tag creation step (version tags now managed in nabledge repository)

### Documentation Updates
- Updated `.claude/rules/release.md` to describe release procedures in nabledge repository
- Updated `.claude/rules/changelog.md` to reflect separation (dev maintains [Unreleased], releases managed in distribution repo)
- Updated README.md to simplify branch strategy and clarify release procedure
- Development guide reference updated (no separate dev guide file needed - nabledge-design.md is sufficient)

## Success Criteria

### Workflow Changes
- [x] GitHub Actions workflow triggers on push to `nabledge-dev:main` (not `release` branch)
- [x] Workflow syncs to `nablarch/nabledge:develop` branch (not `main`)
- [x] Version validation step removed from workflow
- [x] Tag creation step removed from workflow
- [ ] Workflow successfully syncs on first push after changes (requires merge to test)

### Repository Setup
- [ ] `develop` branch created in `nablarch/nabledge` repository (requires manual creation)
- [ ] Branch protection configured if needed (requires manual configuration)

### Documentation Updates
- [x] `.claude/rules/release.md` updated to describe release procedures for nabledge repository
- [x] CHANGELOG management rules updated to reflect new workflow
- [x] README release section updated to describe release procedures for nabledge repository
- [x] Development guide updated to explain new separation

## Next Steps

After merging this PR:

1. Create `develop` branch in `nablarch/nabledge` repository
2. Merge this PR to `main`
3. Verify workflow runs successfully and syncs to `nabledge:develop`
4. Configure branch protection for `develop` and `main` branches in nabledge repository if needed