### PR TITLE
Fix git workflows to use repository default branch

### DIFF
--- a/.claude/skills/git/workflows/branch-create.md
+++ b/.claude/skills/git/workflows/branch-create.md
@@ -1,6 +1,6 @@
 # Branch Creation Workflow
 
-This workflow creates a working branch from the development branch (typically `develop`).
+This workflow creates a working branch from the repository's default branch.
 
 ## Required Tools
 
@@ -11,32 +11,25 @@ This workflow creates a working branch from the development branch (typically `d
 
 ### 1. Pre-flight Checks
 
-**1.1 Get Development Branch and Verify Current Branch**
+**1.1 Get Default Branch and Verify Current Branch**
 
 ```bash
-# Get repository default branch (should be develop per branch strategy)
+# Get repository default branch
 default_branch=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
 echo "Repository default branch: ${default_branch}"
 
-# Verify develop branch exists
-if ! git rev-parse --verify develop &>/dev/null; then
-  echo "Error: Branch 'develop' does not exist in this repository."
+# Verify default branch exists locally
+if ! git rev-parse --verify "${default_branch}" &>/dev/null; then
+  echo "Error: Default branch '${default_branch}' does not exist locally."
   echo ""
-  echo "Please create 'develop' branch first:"
-  echo "  git checkout -b develop main"
-  echo "  git push -u origin develop"
-  echo ""
-  echo "Or update the workflow if using different branch names."
+  echo "Please fetch from remote first:"
+  echo "  git fetch origin"
+  echo "  git checkout ${default_branch}"
   exit 1
 fi
 
-# For branch creation, always use develop as base
-if [[ "$default_branch" == "develop" ]]; then
-  base_branch="develop"
-else
-  echo "WARNING: Repository default is ${default_branch}, but using 'develop' per branch strategy"
-  base_branch="develop"
-fi
+# Use default branch as base
+base_branch="${default_branch}"
 
 # Get current branch
 current_branch=$(git branch --show-current)
@@ -45,10 +38,10 @@ echo "Current branch: ${current_branch}"
 
 If not on the base branch, exit with error:
 
-Error: Working branches must be created from the development branch.
+Error: Working branches must be created from the default branch.
 
 Current branch: ${current_branch}
-Base branch: ${base_branch}
+Default branch: ${base_branch}
 
 To switch to ${base_branch}:
 git checkout ${base_branch}
@@ -81,7 +74,7 @@ echo "Base branch updated successfully"
 
 If pull fails (conflicts):
 
-Error: Failed to update ${base_branch} branch.
+Error: Failed to update ${base_branch} (default branch).
 Please resolve conflicts before proceeding.
 
 ### 2. Get Issue Number and Create Branch Name
@@ -210,9 +203,9 @@ Use `/git commit` to commit changes.
 
 | Error | Response |
 |-------|----------|
-| Not on develop branch | Guide to switch to develop |
+| Not on default branch | Guide to switch to default branch |
 | Uncommitted changes | Guide to commit or stash |
-| Failed to update develop | Guide to resolve conflicts |
+| Failed to update default branch | Guide to resolve conflicts |
 | Branch name exists | Guide to use existing or delete |
 | Issue not found | Guide to create issue first |
 | Invalid issue number | Reject non-numeric input |
@@ -222,7 +215,7 @@ Use `/git commit` to commit changes.
 1. **No emojis**: Never use emojis unless explicitly requested by user
 2. **Issue-driven development**: All branches must be linked to a GitHub issue
 3. **Branch naming**: Always use `<number>-<descriptive-name>` format (e.g., `27-plugin-first-startup-recognition`) for clarity
-4. **Safety**: Protect main/develop branches, check duplicates, verify clean working tree
+4. **Safety**: Protect main/default branches, check duplicates, verify clean working tree
 5. **Issue validation**: Always verify issue exists before creating branch
-6. **Branch strategy**: Branches are created from `develop`, not `main`
+6. **Branch strategy**: Branches are created from repository's default branch (main, develop, etc.)
 7. **Variable syntax**: Always use `${variable}` or `"$variable"` in bash commands for safety

--- a/.claude/skills/git/workflows/worktree-create.md
+++ b/.claude/skills/git/workflows/worktree-create.md
@@ -1,6 +1,6 @@
 # Worktree Creation Workflow
 
-This workflow creates a new worktree for parallel work from the development branch (typically `develop`).
+This workflow creates a new worktree for parallel work from the repository's default branch.
 
 ## Required Tools
 
@@ -23,32 +23,25 @@ echo "Repository name: ${repo_name}"
 echo "Parent directory: ${parent_dir}"
 ```
 
-**1.2 Get Development Branch**
+**1.2 Get Default Branch**
 
 ```bash
-# Get repository default branch (should be develop per branch strategy)
+# Get repository default branch
 default_branch=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
 echo "Repository default branch: ${default_branch}"
 
-# Verify develop branch exists
-if ! git rev-parse --verify develop &>/dev/null; then
-  echo "Error: Branch 'develop' does not exist in this repository."
+# Verify default branch exists locally
+if ! git rev-parse --verify "${default_branch}" &>/dev/null; then
+  echo "Error: Default branch '${default_branch}' does not exist locally."
   echo ""
-  echo "Please create 'develop' branch first:"
-  echo "  git checkout -b develop main"
-  echo "  git push -u origin develop"
-  echo ""
-  echo "Or update the workflow if using different branch names."
+  echo "Please fetch from remote first:"
+  echo "  git fetch origin"
+  echo "  git checkout ${default_branch}"
   exit 1
 fi
 
-# For worktree creation, always use develop as base
-if [[ "$default_branch" == "develop" ]]; then
-  base_branch="develop"
-else
-  echo "WARNING: Repository default is ${default_branch}, but using 'develop' per branch strategy"
-  base_branch="develop"
-fi
+# Use default branch as base
+base_branch="${default_branch}"
 
 echo "Worktree will be created from: ${base_branch}"
 ```
@@ -219,13 +212,13 @@ If user selects "No, cancel", exit gracefully.
 
 ### 4. Create Worktree
 
-**4.1 Update Development Branch**
+**4.1 Update Default Branch**
 
 ```bash
 echo "Updating ${base_branch} from remote..."
 git fetch origin "${base_branch}"
 git pull origin "${base_branch}"
-echo "Base branch updated successfully"
+echo "Default branch updated successfully"
 ```
 
 **4.2 Create Worktree**
@@ -271,7 +264,7 @@ code ${worktree_path}
 |-------|----------|
 | Branch name exists | Guide to use different issue or delete existing |
 | Path exists | Guide to remove existing or use different issue |
-| Failed to update develop | Guide to resolve conflicts |
+| Failed to update default branch | Guide to resolve conflicts |
 | Insufficient permissions | Guide to check write permissions |
 | Insufficient disk space | Guide to check disk space |
 | Issue not found | Guide to create issue first |
@@ -285,7 +278,7 @@ code ${worktree_path}
 3. **Branch naming convention**: `issue-${issue_number}`
 4. **Issue-driven development**: All worktrees must be linked to a GitHub issue
 5. **Issue validation**: Always verify issue exists before creating worktree
-6. **Base branch**: Always branch from `develop`, not `main`
+6. **Base branch**: Always branch from repository's default branch (main, develop, etc.)
 7. **Variable syntax**: Always use `${variable}` or `"$variable"` in bash commands for safety
 8. **Path safety**: Validate parent directory permissions and path availability
 9. **Worktree cleanup**: Use `git worktree remove` instead of `rm -rf` for proper cleanup


### PR DESCRIPTION
## Summary

- Git workflows (branch-create, worktree-create) now detect and use repository's default branch instead of hardcoded 'develop'
- Works in repositories with 'main', 'develop', or any other default branch
- Consistent behavior with other git workflows

## Changes

### Modified Files
- `.claude/skills/git/workflows/branch-create.md` - Use dynamic default branch detection
- `.claude/skills/git/workflows/worktree-create.md` - Use dynamic default branch detection

### Key Updates
1. **Default branch detection**: Use `gh repo view --json defaultBranchRef` to get repository's default branch
2. **Removed hardcoded 'develop'**: No longer assumes 'develop' as base branch
3. **Updated error messages**: Reference "default branch" instead of "develop"
4. **Updated documentation**: Reflect flexible branching strategy in Important Notes

## Test Results

Tested branch detection logic in nabledge-dev (default branch: main):
```
✓ branch-create.md correctly detects and uses 'main'
✓ worktree-create.md correctly detects and uses 'main'
✓ Workflows adapt to repository configuration automatically
```

## Success Criteria

- [x] branch-create.md uses default branch instead of hardcoded 'develop'
- [x] worktree-create.md uses default branch instead of hardcoded 'develop'
- [x] Both workflows successfully work in nabledge-dev (main branch)
- [x] Error messages and documentation updated to reflect default branch usage
- [x] Workflows still work in repositories that use 'develop' as default

Resolves #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)