### PR TITLE
feat: Add push protection for official Nablarch repositories

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -308,6 +308,11 @@ clone_or_update_repo() {
             exit 1
         fi
     fi
+
+    # Disable push to prevent accidental commits to official repositories
+    if git -C "$repo_path" remote set-url --push origin no_push 2>/dev/null; then
+        print_status ok "$repo_name: push protection enabled"
+    fi
 }
 
 # Clone Nablarch 6 repositories (main branch)


### PR DESCRIPTION
## Summary

Enhance `setup.sh` to automatically disable push for all cloned Nablarch official repositories by setting their push URL to "no_push". This prevents accidental commits to official repositories.

## Approach

Modified the `clone_or_update_repo()` function to add a post-clone step that disables push access using:
```bash
git -C "$repo_path" remote set-url --push origin no_push
```

This protection applies to all official repositories:
- nablarch-document (v5, v6)
- nablarch-single-module-archetype (v5, v6)
- nablarch-system-development-guide (v6)

## Tasks

- [x] Add push protection to clone_or_update_repo function
- [x] Add status message for push protection confirmation
- [x] Test with existing repository setup

## Review

Please verify that:
- The protection is applied to all cloned repositories
- Error handling is appropriate (silent failure on git command)
- Status message provides clear feedback to users

## Success Criteria

- [ ] setup.sh successfully disables push for all official repositories
- [ ] Status message confirms push protection is enabled
- [ ] Existing functionality (clone/update) remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)