### PR TITLE
docs: Clarify language policy - developer vs end-user content

### DIFF
--- a/.claude/rules/language.md
+++ b/.claude/rules/language.md
@@ -4,63 +4,60 @@
 
 **Target users**: Japanese developers working on Nablarch projects
 
-**Rationale**: nabledge-x skills serve Japanese Nablarch users, requiring Japanese user-facing messages while maintaining English for technical documentation.
+**Rationale**: Nabledge skills serve Japanese Nablarch users, requiring Japanese for end-user interfaces while maintaining English for developer content.
+
+## Basic Policy
+
+| Audience | Language | Rationale |
+|----------|----------|-----------|
+| End users (Nabledge users) | Japanese | Primary users are Japanese Nablarch developers |
+| Developers (repository contributors) | English | Standard for technical collaboration |
+| AI conversations | Request Japanese individually | Not default; specify when needed |
 
 ## Quick Reference
 
 | Content Type | Language | Examples |
 |--------------|----------|----------|
-| Repository content | English | Code, commits, README, design docs, issues |
-| Console conversations | Japanese | AI responses to user questions |
-| Skills: structure | English | SKILL.md, workflows/*.md headings and logic |
-| Skills: user messages | Japanese | Questions, output headers, error messages |
-| End-user guides | Japanese | plugin/GUIDE-*.md, assets/examples.md |
+| Code | English | Source code, comments, variables, functions |
+| Issues & PRs | English | Titles, descriptions, comments |
+| Commits | English | Commit messages |
+| Developer docs | English | README, design docs, architecture |
+| Skills: structure | English | SKILL.md, workflows/*.md (headings, logic) |
+| Skills: user interface | Japanese | Questions, output, error messages |
+| End-user docs | Japanese | plugin/GUIDE-*.md, assets/examples.md |
 
-## Repository Content (English)
+## Developer Content (English)
 
 Write in English:
-- Source code (comments, variables, functions)
-- Documentation (README, design docs)
-- Git commits and PR descriptions
-- Tests and issues
+- **Source code**: Comments, variables, functions, classes
+- **Issues**: Titles and descriptions
+- **Pull Requests**: Titles and descriptions
+- **Commits**: Commit messages
+- **Documentation**: README.md, design docs, architecture docs
+- **Tests**: Test code and descriptions
+- **Skills structure**: SKILL.md, workflows/*.md (structure and logic)
 
-## Console Conversations (Japanese)
+## End-User Content (Japanese)
 
-AI communicates with users in Japanese:
-- Responses to questions
-- Explanations and guidance
-- Status updates and errors
+Write in Japanese for Nabledge users:
+- **User guides**: plugin/GUIDE-*.md, assets/examples.md
+- **User interface elements**:
+  - AskUserQuestion prompts: `"今日の発見は何ですか？"`
+  - Output headers: `## アウトプット`, `## 発見`
+  - Error messages: `エラー: GitHubリポジトリが見つかりません。`
+  - Status messages shown to users
 
-## Skills Documentation
+## AI Conversations
 
-### AI Agent-Facing: English
+**Default**: Follow context (usually English for development tasks)
 
-Structure and logic in English:
-- `SKILL.md` - Skill definition, execution flow
-- `workflows/*.md` - Workflow steps, logic
-- `docs/*.md` - Technical documentation
+**When Japanese needed**: Explicitly request in Japanese
+- Example: "日本語で説明してください"
+- AI will respond in Japanese when directly requested
 
-**Example**:
-```markdown
-# Standup Report Generator (op)
+## Skills Documentation Pattern
 
-## Execution Flow
-
-### 1. Execute Workflow
-...
-```
-
-### User-Facing: Japanese
-
-Messages users see in Japanese:
-- AskUserQuestion prompts: `"今日の発見は何ですか？"`
-- Output headers: `## アウトプット`, `## 発見`
-- Error messages: `エラー: GitHubリポジトリが見つかりません。`
-- End-user guides: `plugin/GUIDE-CC.md`, `assets/examples.md`
-
-## Common Pattern
-
-Workflows mix English structure with Japanese messages:
+Skills mix English structure with Japanese user interface:
 
 ```markdown
 ### 2. Interview User
@@ -71,3 +68,13 @@ Question: "今日の発見は何ですか？(技術的な気づき、学び、�
 
 Save user's answer as `discoveries`.
 ```
+
+**Structure (English)**:
+- Section headings
+- Logic descriptions
+- Tool instructions
+
+**User interface (Japanese)**:
+- Question text users see
+- Output format users copy
+- Error messages users read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@ Development repository for nabledge skills - AI assistants for Nablarch framewor
 
 ## Language
 
-**Repository content**: English (code, docs, commits, tests)
+**Developer content**: English (code, issues, PRs, commits, docs)
 
-**Console conversations**: Japanese (AI ↔ User)
+**End-user interface**: Japanese (user guides, questions, output, errors)
 
-**Skills**: English structure with Japanese user-facing messages (questions, output, errors)
+**AI conversations**: English by default; request Japanese when needed
 
 See `.claude/rules/language.md` for detailed guidelines and examples.
 


### PR DESCRIPTION
## Summary

Clarified language policy to distinguish between developer content (English) and end-user interface (Japanese). This resolves inconsistency where Issues/PRs were mixed Japanese/English.

**Key Changes:**
- Updated `.claude/rules/language.md` with clear policy distinction
- Updated `CLAUDE.md` Language section to reflect new policy
- Explicitly specified Issues/PRs should be in English

## Changes

### Developer Content (English)

All developer-facing content in English:
- Code, comments, variables, functions
- Issues: titles and descriptions
- Pull Requests: titles and descriptions
- Commits: commit messages
- Documentation: README, design docs, architecture docs
- Skills structure: SKILL.md, workflows/*.md (logic)

### End-User Interface (Japanese)

All end-user-facing content in Japanese:
- User guides: plugin/GUIDE-*.md, assets/examples.md
- User interface elements:
  - AskUserQuestion prompts
  - Output headers (## アウトプット, ## 発見)
  - Error messages
  - Status messages

### AI Conversations

- **Default**: English (follow development context)
- **Japanese**: Explicitly request when needed (e.g., "日本語で説明してください")

## Rationale

**Before:** Language policy was ambiguous
- "Repository content: English" but unclear if Issues/PRs included
- "Console conversations: Japanese" but unclear when to apply
- Issues #68 and PR #66 were written in Japanese, inconsistent with English policy

**After:** Clear distinction by audience
- Developer content (Issues, PRs, docs) → English for collaboration
- End-user interface (guides, messages) → Japanese for Nablarch users
- AI conversations → English by default, Japanese on request

## Impact

**Consistency:**
- All Issues/PRs should be in English going forward
- Documentation structure in English, user-facing messages in Japanese
- Clear guideline for contributors

**Examples already updated:**
- Issue #68: Updated to English
- PR #66: Updated to English

## Files Changed

- `.claude/rules/language.md` (+52 lines, -45 lines)
  - Added "Basic Policy" section with audience distinction
  - Clarified "Developer Content" section
  - Added "AI Conversations" section
- `CLAUDE.md` (+4 lines, -4 lines)
  - Updated Language section to reflect new policy

## Test Plan

- [ ] Verify language.md is clear and unambiguous
- [ ] Verify CLAUDE.md summary matches detailed rules
- [ ] Check that future Issues/PRs follow English policy

🤖 Generated with Claude Code