### PR TITLE
Fix prefill-template.sh to handle absolute paths correctly (#110)

### DIFF
--- a/.claude/skills/nabledge-6/scripts/prefill-template.sh
+++ b/.claude/skills/nabledge-6/scripts/prefill-template.sh
@@ -35,6 +35,11 @@ Example:
      --modules "proman-web" \\
      --source-files "LoginAction.java,LoginForm.java" \\
      --knowledge-files "universal-dao,web-application"
+
+# Example output:
+# Pre-filled template written to: .nabledge/20260303/code-analysis-LoginAction.md
+# ...
+# Output: .nabledge/20260303/code-analysis-LoginAction.md
 EOF
     exit 1
 }
@@ -82,6 +87,12 @@ done
 if [[ -z "$TARGET_NAME" || -z "$TARGET_DESC" || -z "$MODULES" || -z "$SOURCE_FILES" || -z "$KNOWLEDGE_FILES" ]]; then
     echo "Error: Missing required arguments" >&2
     usage
+fi
+
+# Validate jq availability (required for official docs extraction)
+if ! command -v jq &> /dev/null; then
+    echo "Warning: jq not found. Official documentation links cannot be extracted from knowledge files." >&2
+    echo "Install jq to enable automatic official docs extraction." >&2
 fi
 
 # Calculate output path internally
@@ -330,6 +341,12 @@ awk -v links="$OFFICIAL_DOCS_LINKS" '{gsub(/\{\{official_docs_links\}\}/, links)
 
 # Copy to output path
 cp "$TEMP_FILE" "$OUTPUT_PATH"
+
+# Verify write succeeded
+if [ ! -f "$OUTPUT_PATH" ]; then
+    echo "Error: Failed to write output file to $OUTPUT_PATH" >&2
+    exit 1
+fi
 
 # Trap will clean up temp files automatically
 

--- a/.claude/skills/nabledge-6/workflows/code-analysis.md
+++ b/.claude/skills/nabledge-6/workflows/code-analysis.md
@@ -213,6 +213,7 @@ cat .claude/skills/nabledge-6/assets/code-analysis-template.md \
 
 ```bash
 # Execute prefill script (now calculates output path internally)
+# Capture output path from the script's final "Output: <path>" line
 OUTPUT_PATH=$(.claude/skills/nabledge-6/scripts/prefill-template.sh \
   --target-name "<target-name>" \
   --target-desc "<one-line-description>" \

--- a/.pr/00110/review-by-software-engineer.md
+++ b/.pr/00110/review-by-software-engineer.md
@@ -1,0 +1,74 @@
+# Expert Review: Software Engineer
+
+**Date**: 2026-03-03
+**Reviewer**: AI Agent as Software Engineer
+**Files Reviewed**: 2 files
+
+## Overall Assessment
+
+**Rating**: 4/5
+**Summary**: This is a well-executed refactoring that significantly improves the script's maintainability and reduces API complexity. The changes follow solid engineering principles, with good defensive programming practices and clear documentation updates.
+
+## Key Issues
+
+### High Priority
+None identified.
+
+### Medium Priority
+
+1. **Missing jq dependency check at script start**
+   - **Description**: The script extracts official docs from JSON using `jq` but only checks availability inside the extraction loop. If `jq` is missing, the script silently produces no official docs without early warning.
+   - **Suggestion**: Add jq availability check in validation section to warn users early
+   - **Decision**: Implement Now ✅
+   - **Reasoning**: Early validation prevents confusion when official docs are missing. Users should know upfront if a dependency is missing.
+   - **Implementation**: Added warning check after argument validation (lines 92-95)
+
+2. **Hardcoded relative path depth assumption**
+   - **Description**: Line 148 sets `RELATIVE_PREFIX="../../"` assuming output will always be 2 levels deep. If path structure changes, links will break.
+   - **Suggestion**: Add validation to verify OUTPUT_DIR depth matches assumption
+   - **Decision**: Reject
+   - **Reasoning**: Script is designed for specific directory structure (.claude/skills/nabledge-6/knowledge/). Runtime validation adds complexity without benefit. If path structure changes, entire script needs updating anyway. Current approach is intentional.
+
+3. **Potential duplicate official docs from overlapping knowledge files**
+   - **Description**: Current `sort -u` deduplication may not handle URLs with different formatting (trailing slash, query params)
+   - **Suggestion**: Enhance deduplication by normalizing URLs
+   - **Decision**: Defer to Future
+   - **Reasoning**: Current deduplication handles most cases adequately. URL normalization is complex and addresses edge cases. Can optimize if users report duplicate link issues.
+
+### Low Priority
+
+1. **Inconsistent error message formatting**
+   - **Decision**: Defer to Future
+   - **Reasoning**: Purely cosmetic, doesn't affect functionality
+
+2. **No validation that OUTPUT_PATH write succeeded**
+   - **Description**: Script doesn't verify write operation succeeded
+   - **Suggestion**: Add validation after copy operation
+   - **Decision**: Implement Now ✅
+   - **Reasoning**: Silent write failures cause user confusion. Simple validation catches disk full or permission errors.
+   - **Implementation**: Added file existence check after write (lines 345-349)
+
+3. **basename extraction could fail for edge cases**
+   - **Decision**: Reject
+   - **Reasoning**: Current code already has empty string checks. Edge cases are extremely unlikely in real usage.
+
+## Positive Aspects
+
+- **Excellent defensive programming**: `basename` extraction elegantly handles accidental path inputs while maintaining backward compatibility
+- **Clear documentation**: Updated usage message comprehensively explains new behavior with practical examples
+- **Single Responsibility improvement**: Removing external path inputs makes script more focused
+- **Reduced coupling**: Official docs extraction from JSON eliminates caller duplication
+- **Maintained error handling**: Preserves warning messages for missing files and continues processing
+- **Output path communication**: Clear design for capturing output path via stdout parsing
+
+## Recommendations
+
+1. **Add integration test**: Create test script verifying output path calculation, official docs extraction, and defensive basename handling
+2. **Consider extracting official docs logic**: Lines 249-284 could become separate function for better testability
+3. **Document jq dependency**: Add note in script header that jq is optional but recommended
+4. **Version the output format**: Consider adding version marker to stdout output for future format changes
+
+## Files Reviewed
+
+- `.claude/skills/nabledge-6/scripts/prefill-template.sh` (Shell script)
+- `.claude/skills/nabledge-6/workflows/code-analysis.md` (Workflow documentation)

--- a/.pr/00110/review-by-technical-writer.md
+++ b/.pr/00110/review-by-technical-writer.md
@@ -1,0 +1,77 @@
+# Expert Review: Technical Writer
+
+**Date**: 2026-03-03
+**Reviewer**: AI Agent as Technical Writer
+**Files Reviewed**: 2 files
+
+## Overall Assessment
+
+**Rating**: 4/5
+**Summary**: The documentation updates are well-structured and accurately reflect the API simplification. The changes maintain consistency with existing documentation patterns and provide clear guidance. Minor improvements in organization and example clarity were implemented.
+
+## Key Issues
+
+### Medium Priority
+
+1. **Usage Example Incomplete Context**
+   - **Description**: Usage message shows example invocation but doesn't explain stdout output format, which is crucial since workflow captures this output
+   - **Suggestion**: Add comment showing expected stdout output format in example
+   - **Decision**: Implement Now ✅
+   - **Reasoning**: Helps users understand what to expect when running the script, especially since workflow relies on parsing this output.
+   - **Implementation**: Added example output format comment (lines 39-42)
+
+2. **Parameter Description Redundancy**
+   - **Description**: Workflow repeats defensive handling notes in multiple places
+   - **Suggestion**: Move defensive handling details to single "Parameter Guidelines" subsection
+   - **Decision**: Reject
+   - **Reasoning**: Current structure repeats for clarity. Each parameter section is self-contained, making it easier to understand requirements at a glance. Consolidating would require cross-referencing, reducing readability. Redundancy is intentional for documentation clarity.
+
+3. **Output Path Capture Example Complexity**
+   - **Description**: The bash command using grep/cut to extract output path isn't explained
+   - **Suggestion**: Add comment explaining the extraction pattern
+   - **Decision**: Implement Now ✅
+   - **Reasoning**: The pattern is not immediately obvious. Brief comment improves maintainability and helps users adapt the example.
+   - **Implementation**: Added extraction pattern comment (line 216)
+
+### Low Priority
+
+1. **Inconsistent Section Heading Levels**
+   - **Description**: Workflow subsection numbering doesn't align with heading hierarchy
+   - **Suggestion**: Promote subsections to formal subheadings or add transition sentence
+   - **Decision**: Defer to Future
+   - **Reasoning**: Current structure is functional. Can be addressed during broader documentation review.
+
+2. **Missing Validation Guidance**
+   - **Description**: Workflow doesn't mention what to do if script fails or OUTPUT_PATH capture fails
+   - **Suggestion**: Add brief error handling note in Step 3.2
+   - **Decision**: Defer to Future
+   - **Reasoning**: Workflow already has general error handling guidelines. Specific guidance for this step can be added if users report confusion.
+
+## Positive Aspects
+
+- **Clear API simplification**: Removal of `--output-path` and `--official-docs` well-documented with explicit notes about automatic behavior
+- **Defensive design documentation**: Excellent documentation of basename handling that alerts workflow authors to API robustness
+- **Consistent terminology**: "basename" terminology used consistently throughout both files
+- **Practical examples**: Workflow includes concrete examples (LoginAction.java, universal-dao) that make abstract concepts tangible
+- **Cross-reference accuracy**: File path references in Step 3.5 correctly reference captured `$OUTPUT_PATH` variable from Step 3.2
+- **Progressive disclosure**: Usage message provides essential information first, detailed notes second, example last—excellent information architecture
+
+## Recommendations
+
+1. **Add troubleshooting section**: Consider adding "Common Issues" section addressing scenarios like:
+   - Multiple file matches requiring disambiguation
+   - Missing jq for official docs extraction
+   - Invalid knowledge file names
+
+2. **Enhance workflow prerequisites**: Step 3.2 could benefit from "Prerequisites" subsection listing required tools (bash, jq, git)
+
+3. **Visual consistency**: Standardize on inline code (backticks) for paths in prose and code blocks only for executable commands
+
+4. **Version compatibility note**: Since script now uses `jq` for JSON parsing, consider adding note about jq availability
+
+5. **Link to template structure**: Users might benefit from reference link to template file for understanding placeholder structure
+
+## Files Reviewed
+
+- `.claude/skills/nabledge-6/scripts/prefill-template.sh` (Shell script usage documentation)
+- `.claude/skills/nabledge-6/workflows/code-analysis.md` (Workflow documentation)


### PR DESCRIPTION
Closes #110

## Approach

Simplify `prefill-template.sh` by removing external path inputs and calculating output location internally based on conventions.

**Root cause**: The script accepts `--output-path` from external callers (agents), which can pass absolute paths causing incorrect relative link depth calculation.

**Solution**: Remove `--output-path` and `--official-docs` parameters. Generate output path internally following project conventions:
- Output directory: `.nabledge/$(date '+%Y%m%d')`
- Output filename: `code-analysis-${TARGET_NAME}.md`
- Relative path prefix: Always `../../` (fixed 2-level depth)
- Official docs: Extract from `official_doc_urls` field in knowledge JSON files

**Why this approach**:
- **Eliminates root cause**: External callers cannot pass absolute paths for output
- **Simpler design**: Fewer parameters, clearer conventions
- **More robust**: No path calculation logic needed, fixed depth
- **Self-documenting**: Output path printed to stdout for caller to capture
- **Defensive**: Input parameters accept paths defensively but workflows should pass basenames

**Design changes**:
1. Remove `--output-path` parameter
2. Remove `--official-docs` parameter  
3. Calculate output path internally using `TARGET_NAME` and current date
4. Fix relative prefix to `../../` (no dynamic calculation)
5. Extract official doc URLs from knowledge JSON files' `official_doc_urls` field
6. Defensively handle `--source-files` and `--knowledge-files` if paths provided (extract basename)

## Tasks

- [x] Remove `--output-path` parameter from argument parsing
- [x] Remove `--official-docs` parameter from argument parsing
- [x] Add internal output path calculation logic
- [x] Fix relative path prefix to `../../` (remove dynamic calculation)
- [x] Add defensive basename extraction for `--source-files` (handle absolute/relative paths)
- [x] Add defensive basename extraction for `--knowledge-files` (handle absolute/relative paths + .json removal)
- [x] Add JSON parsing to extract `official_doc_urls` from knowledge files using `jq`
- [x] Update usage documentation in script header (specify basename-only input)
- [x] Print final output path to stdout for caller
- [x] Update `workflows/code-analysis.md` to specify basename-only parameters
- [x] Test with basename inputs (standard case)
- [x] Test with absolute/relative path inputs (defensive handling)
- [x] Test official doc URL collection from multiple knowledge files
- [x] Verify script output path format for caller consumption
- [x] Expert review: Software Engineer (Rating: 4/5)
- [x] Expert review: Technical Writer (Rating: 4/5)
- [x] Implement approved improvements from expert reviews

## Expert Review

AI-driven expert reviews conducted and improvements implemented (see `.claude/rules/expert-review.md`):

- [Software Engineer](../.pr/00110/review-by-software-engineer.md) - Rating: 4/5
- [Technical Writer](../.pr/00110/review-by-technical-writer.md) - Rating: 4/5

**Improvements implemented from reviews**:
1. Added jq availability check with user-friendly warning
2. Added output file write validation
3. Added usage example showing expected stdout format
4. Added comment explaining output path extraction pattern

## Success Criteria Check

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `scripts/prefill-template.sh` normalizes absolute paths to relative paths before depth calculation | ✅ Updated | Design changed: script generates output path internally, eliminating absolute path inputs entirely |
| Script correctly generates 2-level links for `.nabledge/YYYYMMDD/*.md` files regardless of absolute/relative input | ✅ Met | Relative path prefix fixed to `../../`, no calculation needed. Tested successfully. |
| Test with absolute path: `/home/user/project/.nabledge/20260303/test.md` generates `../../src/` links | ✅ Updated | `--output-path` parameter removed; script determines path internally |
| Test with relative path: `.nabledge/20260303/test.md` generates `../../src/` links | ✅ Met | Script generates consistent `../../` prefix for all outputs. Tested successfully. |
| Existing functionality with relative paths remains unchanged | ⚠️ Breaking | **Breaking change**: Callers must update to remove `--output-path` and `--official-docs` parameters, read output path from stdout |

## Test Results

**Test 1: Basename inputs (standard case)**
```bash
--source-files "TestClass.java"
--knowledge-files "universal-dao"
```
✅ Generated correct links with `../../` prefix
✅ Extracted official docs from universal-dao.json

**Test 2: Defensive handling (absolute/relative paths)**
```bash
--source-files "/home/user/project/src/main/java/TestClass.java,./src/TestClass.java"
--knowledge-files "/path/to/universal-dao.json,.claude/skills/nabledge-6/knowledge/universal-dao.json"
```
✅ Basename extraction worked correctly
✅ Generated correct links despite path inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)