### PR TITLE
chore: remove .gitattributes to fix spurious httpDump.bat diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-* text=auto eol=lf
-*.bat text eol=crlf


### PR DESCRIPTION
## Approach

`.gitattributes` に `*.bat text eol=crlf` ルールが設定されており、WSL環境でCRLF/LF変換の差分が `httpDump.bat` に対して常に発生していた。`.gitattributes` を削除することで問題を解消する。

## Tasks

- [x] `.gitattributes` を削除

## Expert Review

なし（設定ファイル削除のみのシンプルな変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)