### PR TITLE
fix: add nabledge-5 knowledge and docs to sync-manifest

### DIFF
--- a/.github/workflows/sync-to-nabledge/sync-manifest.txt
+++ b/.github/workflows/sync-to-nabledge/sync-manifest.txt
@@ -45,11 +45,11 @@ file	.claude/skills/nabledge-5/plugin/GUIDE-CC.md	plugins/nabledge-5/GUIDE-CC.md
 file	.claude/skills/nabledge-5/plugin/GUIDE-GHC.md	plugins/nabledge-5/GUIDE-GHC.md
 
 # --- nabledge-5 skill content ---
-# Note: knowledge/ and docs/ are intentionally omitted here.
-# They will be added in a separate issue once nabledge-5 knowledge files are generated.
 file	.claude/skills/nabledge-5/SKILL.md	plugins/nabledge-5/skills/nabledge-5/SKILL.md
 dir	.claude/skills/nabledge-5/workflows	plugins/nabledge-5/skills/nabledge-5/workflows
 dir	.claude/skills/nabledge-5/assets	plugins/nabledge-5/skills/nabledge-5/assets
+dir	.claude/skills/nabledge-5/knowledge	plugins/nabledge-5/skills/nabledge-5/knowledge
+dir	.claude/skills/nabledge-5/docs	plugins/nabledge-5/skills/nabledge-5/docs
 dir	.claude/skills/nabledge-5/scripts	plugins/nabledge-5/skills/nabledge-5/scripts
 
 # --- n5 CC command ---


### PR DESCRIPTION
## Approach

nabledge-5 knowledge/ and docs/ were intentionally omitted from sync-manifest,
pending knowledge file generation. Since generation is complete (#121),
add them so they are distributed to nablarch/nabledge.

## Tasks

- [x] Add nabledge-5 knowledge/ to sync-manifest
- [x] Add nabledge-5 docs/ to sync-manifest
- [x] Remove outdated comment about intentional omission

## Expert Review

N/A (single-line config change)

## Success Criteria Check

| Criterion | Status | Evidence |
|-----------|--------|----------|
| setup-cc.sh -v 5 installs knowledge/ | ✅ Met | dir entry added to sync-manifest |
| setup-ghc.sh -v 5 installs knowledge/ | ✅ Met | dir entry added to sync-manifest |
| No more `Warning: knowledge/ directory not found` on install | ✅ Met | knowledge/ will be distributed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)