### PR TITLE
fix: populate v5 catalog.json source commit SHAs (#221)

### DIFF
--- a/tools/knowledge-creator/.cache/v5/catalog.json
+++ b/tools/knowledge-creator/.cache/v5/catalog.json
@@ -4,12 +4,12 @@
     {
       "repo": "https://github.com/nablarch/nablarch-document",
       "branch": "v5-main",
-      "commit": ""
+      "commit": "264d7338d5caee144852e74709992a0383d2febf"
     },
     {
       "repo": "https://github.com/Fintan-contents/nablarch-system-development-guide",
       "branch": "main",
-      "commit": ""
+      "commit": "3c34cc3a75da0c4ce85620d8002f1c004f2bb753"
     }
   ],
   "files": [


### PR DESCRIPTION
Closes #221

## Approach

`catalog.json` for v5 had empty `commit` fields in its `sources` entries. This prevented `kc regen 5` from detecting source changes — `detect_changed_files()` treats empty commit as first generation and falls back to regenerating all files.

The fix records the actual HEAD commit SHAs of the two v5 source repositories at the time the knowledge files were generated (2026-03-13). Both commits match the current local clone HEADs, confirmed via `git log --before`.

## Tasks

- [x] Record `nablarch-document` v5-main HEAD SHA in catalog.json sources
- [x] Record `nablarch-system-development-guide` main HEAD SHA in catalog.json sources

## Expert Review

No code logic changed — data-only fix. Expert review not applicable.

## Success Criteria Check

| Criterion | Status | Evidence |
|-----------|--------|----------|
| catalog.json sources for v5 have non-empty commit SHAs matching current HEAD | ✅ Met | `264d7338` (nablarch-document) and `3c34cc3a` (nablarch-system-development-guide) |
| `kc.sh regen 5` detects no changes when sources are up-to-date | ✅ Met | `python scripts/run.py --version 5 --regen` output: "ソース変更なし" |

🤖 Generated with [Claude Code](https://claude.com/claude-code)