### PR TITLE
fix: use unique cloners instead of total clone count in metrics

### DIFF
--- a/tools/metrics/collect.py
+++ b/tools/metrics/collect.py
@@ -865,8 +865,8 @@ def render_metrics_md(
             lines.append("")
 
         if snap_clones:
-            c_labels, c_counts, _ = aggregate_traffic_weekly(snap_clones)
-            lines.append(mermaid_xychart_bar("Git Clones (weekly)", c_labels, "Clones", c_counts))
+            c_labels, _, c_uniques = aggregate_traffic_weekly(snap_clones)
+            lines.append(mermaid_xychart_bar("Unique Cloners (weekly)", c_labels, "Cloners", c_uniques))
             lines.append("")
     elif traffic_snapshot is None:
         lines.append("## Nabledge Adoption (nablarch/nabledge)")


### PR DESCRIPTION
## Summary

- Git Clones chart was showing inflated numbers (1,448–2,822 clones/week vs. 28–40 unique visitors)
- Root cause: using `count` (total git operations) from GitHub Traffic API, which includes repeated fetches (e.g., periodic update checks by Claude Code)
- Switch to `uniques` (unique cloners) for an accurate adoption signal
- Update chart title and axis label to "Unique Cloners (weekly)"

## Changes

- `tools/metrics/collect.py`: use `c_uniques` instead of `c_counts`; update chart title and axis label