### PR TITLE
release: publish marketplace v0.7 with nabledge-1.4 and nabledge-6 v0.7 (#253)

### DIFF
--- a/.claude/marketplace/.claude-plugin/marketplace.json
+++ b/.claude/marketplace/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Nablarch"
   },
   "metadata": {
-    "version": "0.6",
+    "version": "0.7",
     "description": "Nablarch skills for AI-assisted development"
   },
   "plugins": [

--- a/.claude/marketplace/CHANGELOG.md
+++ b/.claude/marketplace/CHANGELOG.md
@@ -8,6 +8,7 @@ Nabledgeマーケットプレイス全体のバージョン対応表です。
 
 | マーケットプレイスバージョン | nabledge-6 | nabledge-5 | nabledge-1.4 | リリース日 |
 |---------------------------|-----------|-----------|-------------|----------|
+| 0.7 | [0.7](plugins/nabledge-6/CHANGELOG.md#07---2026-03-27) | [0.1](plugins/nabledge-5/CHANGELOG.md#01---2026-03-13) | [0.1](plugins/nabledge-1.4/CHANGELOG.md#01---2026-03-27) | 2026-03-27 |
 | 0.6 | [0.6](plugins/nabledge-6/CHANGELOG.md#06---2026-03-13) | [0.1](plugins/nabledge-5/CHANGELOG.md#01---2026-03-13) | - | 2026-03-13 |
 | 0.5 | [0.5](plugins/nabledge-6/CHANGELOG.md#05---2026-03-10) | - | - | 2026-03-10 |
 | 0.4 | [0.4](plugins/nabledge-6/CHANGELOG.md#04---2026-03-04) | - | - | 2026-03-04 |

--- a/.claude/skills/nabledge-1.4/plugin/CHANGELOG.md
+++ b/.claude/skills/nabledge-1.4/plugin/CHANGELOG.md
@@ -4,8 +4,10 @@ nabledge-1.4プラグインの主な変更内容を記録しています。
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) に基づいています。
 
-## [Unreleased]
+## [0.1] - 2026-03-27
 
 ### 追加
 
 - Nablarch 1.4の全ドキュメントをカバーする知識ファイルを追加しました。
+
+[0.1]: https://github.com/nablarch/nabledge/releases/tag/0.7

--- a/.claude/skills/nabledge-6/plugin/CHANGELOG.md
+++ b/.claude/skills/nabledge-6/plugin/CHANGELOG.md
@@ -4,6 +4,11 @@ nabledge-6プラグインの主な変更内容を記録しています。
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) に基づいています。
 
+## [0.7] - 2026-03-27
+
+### 追加
+- インストールガイドにトラブルシューティングセクションを追加しました。プロキシ環境や権限不足によるインストール失敗時の対処方法を確認できます。
+
 ## [0.6] - 2026-03-13
 
 ### 追加
@@ -45,6 +50,7 @@ nabledge-6プラグインの主な変更内容を記録しています。
 ### 追加
 - 評価版として、Nablarch 6のバッチ処理に関する基礎知識とコード分析ワークフローを提供
 
+[0.7]: https://github.com/nablarch/nabledge/releases/tag/0.7
 [0.6]: https://github.com/nablarch/nabledge/releases/tag/0.6
 [0.5]: https://github.com/nablarch/nabledge/releases/tag/0.5
 [0.4]: https://github.com/nablarch/nabledge/releases/tag/0.4

--- a/.claude/skills/nabledge-6/plugin/plugin.json
+++ b/.claude/skills/nabledge-6/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nabledge-6",
-  "version": "0.6",
+  "version": "0.7",
   "description": "Nablarch 6 skill for AI-assisted development",
   "author": {
     "name": "Nablarch"

--- a/.pr/00253/notes.md
+++ b/.pr/00253/notes.md
@@ -1,0 +1,32 @@
+# Notes
+
+## 2026-03-27
+
+### Release v0.7 Analysis
+
+**Commits since v0.6 (2026-03-13) affecting deployed content:**
+- `434685a5` feat: generate nabledge-1.4 knowledge files and baseline (#122) (#224) — nabledge-1.4 new plugin
+- `fc356bfd` docs: add troubleshooting section to install guides (#211) (#212) — nabledge-6 GUIDE-CC/GHC updated
+
+**Version decisions:**
+- nabledge-6: 0.6 → 0.7 (minor: troubleshooting docs added)
+- nabledge-5: unchanged at 0.1
+- nabledge-1.4: 0.1 (first release, included in marketplace 0.7)
+- Marketplace: 0.7 (highest changed plugin version)
+
+**nabledge-1.4 tag link:** Points to `releases/tag/0.7` (the marketplace release where it first appears)
+
+### Comparison with PR #196 (v0.6 release)
+
+Previous release PR #196 updated:
+- `.claude/marketplace/.claude-plugin/marketplace.json` ✅
+- `.claude/marketplace/CHANGELOG.md` ✅
+- `.claude/skills/nabledge-5/plugin/CHANGELOG.md` (nabledge-5 had first release then)
+- `.claude/skills/nabledge-6/plugin/CHANGELOG.md` ✅
+- `.claude/skills/nabledge-6/plugin/plugin.json` ✅
+- `.pr/00195/notes.md` (work log, not release-specific)
+
+This PR updates the same required files plus adds:
+- `.claude/skills/nabledge-1.4/plugin/CHANGELOG.md` (nabledge-1.4 first release)
+
+nabledge-5's CHANGELOG/plugin.json not updated because nabledge-5 has no changes since v0.1.

--- a/.pr/00253/review-by-devops-engineer.md
+++ b/.pr/00253/review-by-devops-engineer.md
@@ -1,0 +1,48 @@
+# Expert Review: DevOps Engineer
+
+**Date**: 2026-03-27
+**Reviewer**: AI Agent as DevOps Engineer
+**Files Reviewed**: 5 files
+
+## Overall Assessment
+
+**Rating**: 5/5
+**Summary**: Version changes are clean, internally consistent, and follow the established release pattern. No security concerns. All cross-file version references are accurate.
+
+## Key Issues
+
+### High Priority
+
+None.
+
+### Medium Priority
+
+None.
+
+### Low Priority
+
+1. **nabledge-5 plugin.json omission is implicit**
+   - Description: nabledge-5 is intentionally unchanged at v0.1, but the omission is not documented in the diff itself
+   - Decision: Defer — noted in PR description and work log
+   - Reasoning: Acceptable; the release analysis confirms it is intentional
+
+## Positive Aspects
+
+- Version consistency: `marketplace.json` v0.7, `nabledge-6/plugin.json` v0.7, CHANGELOG `[0.7]` all align
+- Tag link for nabledge-1.4 correctly points to marketplace v0.7 release (first appearance)
+- nabledge-5 tag link in marketplace row preserved correctly without version bump
+- No secrets or credentials exposed; config files contain only version strings and public GitHub URLs
+- GitHub URLs reference canonical distribution repository (`nablarch/nabledge`), not dev repository
+- `[Unreleased]` correctly replaced (not duplicated) in nabledge-1.4 CHANGELOG
+
+## Recommendations
+
+- Consider a CI check to validate version string consistency across the 4-5 required release files (future improvement)
+
+## Files Reviewed
+
+- `.claude/marketplace/.claude-plugin/marketplace.json` (configuration)
+- `.claude/marketplace/CHANGELOG.md` (documentation)
+- `.claude/skills/nabledge-6/plugin/CHANGELOG.md` (documentation)
+- `.claude/skills/nabledge-6/plugin/plugin.json` (configuration)
+- `.claude/skills/nabledge-1.4/plugin/CHANGELOG.md` (documentation)

--- a/.pr/00253/review-by-technical-writer.md
+++ b/.pr/00253/review-by-technical-writer.md
@@ -1,0 +1,54 @@
+# Expert Review: Technical Writer
+
+**Date**: 2026-03-27
+**Reviewer**: AI Agent as Technical Writer
+**Files Reviewed**: 5 files
+
+## Overall Assessment
+
+**Rating**: 4/5
+**Summary**: The release documentation is well-structured and follows established conventions. CHANGELOG entries are concise, user-focused, and written in appropriate Japanese. One low-priority wording improvement was applied.
+
+## Key Issues
+
+### High Priority
+
+None.
+
+### Medium Priority
+
+1. **Marketplace CHANGELOG table column structure**
+   - Description: Concern that older rows might lack the nabledge-1.4 column placeholder
+   - Decision: Reject — table header already included `nabledge-1.4` column with `-` for older rows
+   - Reasoning: Verified against original file; no structural issue exists
+
+2. **nabledge-1.4 [Unreleased] section after release**
+   - Description: Keep a Changelog convention suggests re-adding [Unreleased] after releasing
+   - Decision: Reject — project policy (`changelog.md` rule) explicitly states to remove empty [Unreleased] and re-add in next development cycle
+   - Reasoning: Intentional per project policy
+
+### Low Priority
+
+3. **nabledge-6 CHANGELOG Japanese wording**
+   - Description: "失敗する場合の" → "失敗時の" for conciseness
+   - Decision: Implement Now
+   - Reasoning: Minor but valid improvement; applied to reduce verbosity
+
+4. **"知識ファイル" terminology consistency**
+   - Decision: No action — confirmed consistent with nabledge-6 CHANGELOG usage
+
+## Positive Aspects
+
+- User-focused language: entries describe user impact, not technical implementation
+- Tag link for nabledge-1.4 correctly points to marketplace v0.7 tag (per project convention for first-release plugins)
+- Version numbers consistent across `marketplace.json`, `plugin.json`, and CHANGELOG sections
+- nabledge-5 correctly omitted (no changes since v0.1)
+- Dates consistent across all three CHANGELOG files (2026-03-27)
+
+## Files Reviewed
+
+- `.claude/marketplace/CHANGELOG.md` (documentation)
+- `.claude/marketplace/.claude-plugin/marketplace.json` (configuration)
+- `.claude/skills/nabledge-6/plugin/CHANGELOG.md` (documentation)
+- `.claude/skills/nabledge-6/plugin/plugin.json` (configuration)
+- `.claude/skills/nabledge-1.4/plugin/CHANGELOG.md` (documentation)


### PR DESCRIPTION
## Summary

Closes #253

Release preparation for marketplace v0.7:
- nabledge-1.4 first release (v0.1) — new plugin for Nablarch 1.x development support
- nabledge-6 updated to v0.7 — troubleshooting section added to setup guides
- marketplace.json and CHANGELOG.md updated to v0.7

## Approach

Analyzed all commits since v0.6 (2026-03-13) to identify user-impact changes under deployed content scope. Updated 5 release artifact files after confirming CHANGELOG entries with user.

## Tasks

- [x] `.claude/skills/nabledge-6/plugin/CHANGELOG.md` — [Unreleased] moved to [0.7] with today's date, tag link added
- [x] `.claude/skills/nabledge-6/plugin/plugin.json` — version updated to 0.7
- [x] `.claude/skills/nabledge-1.4/plugin/CHANGELOG.md` — [Unreleased] moved to [0.1] with today's date, tag link added
- [x] `.claude/marketplace/CHANGELOG.md` — v0.7 row added to version table
- [x] `.claude/marketplace/.claude-plugin/marketplace.json` — version updated to 0.7

## Expert Review

- [Technical Writer](https://github.com/nablarch/nabledge-dev/blob/253-release-07/.pr/00253/review-by-technical-writer.md) - Rating: 4/5
- [DevOps Engineer](https://github.com/nablarch/nabledge-dev/blob/253-release-07/.pr/00253/review-by-devops-engineer.md) - Rating: 5/5

## Success Criteria Check

- [x] nabledge-6: 0.7 (minor update: troubleshooting docs added)
- [x] nabledge-5: 0.1 (unchanged, no entry in this release)
- [x] nabledge-1.4: 0.1 (first release)
- [x] Marketplace: 0.7 (highest changed plugin version)
- [x] `.claude/skills/nabledge-6/plugin/CHANGELOG.md` updated
- [x] `.claude/skills/nabledge-6/plugin/plugin.json` updated to 0.7
- [x] `.claude/skills/nabledge-1.4/plugin/CHANGELOG.md` updated
- [x] `.claude/marketplace/CHANGELOG.md` updated
- [x] `.claude/marketplace/.claude-plugin/marketplace.json` updated to 0.7
- [x] Commits since v0.6 analyzed and user-impact entries confirmed
- [x] CHANGELOG entries reviewed and approved by user before file updates
- [x] Changed files compared against previous release PR (#122) — all 5 required files present