### PR TITLE
release: nabledge-5 v0.2 in marketplace v0.7 (#257)

### DIFF
--- a/.claude/marketplace/CHANGELOG.md
+++ b/.claude/marketplace/CHANGELOG.md
@@ -8,7 +8,7 @@ Nabledgeマーケットプレイス全体のバージョン対応表です。
 
 | マーケットプレイスバージョン | nabledge-6 | nabledge-5 | nabledge-1.4 | リリース日 |
 |---------------------------|-----------|-----------|-------------|----------|
-| 0.7 | [0.7](plugins/nabledge-6/CHANGELOG.md#07---2026-03-27) | [0.1](plugins/nabledge-5/CHANGELOG.md#01---2026-03-13) | [0.1](plugins/nabledge-1.4/CHANGELOG.md#01---2026-03-27) | 2026-03-27 |
+| 0.7 | [0.7](plugins/nabledge-6/CHANGELOG.md#07---2026-03-27) | [0.2](plugins/nabledge-5/CHANGELOG.md#02---2026-03-27) | [0.1](plugins/nabledge-1.4/CHANGELOG.md#01---2026-03-27) | 2026-03-27 |
 | 0.6 | [0.6](plugins/nabledge-6/CHANGELOG.md#06---2026-03-13) | [0.1](plugins/nabledge-5/CHANGELOG.md#01---2026-03-13) | - | 2026-03-13 |
 | 0.5 | [0.5](plugins/nabledge-6/CHANGELOG.md#05---2026-03-10) | - | - | 2026-03-10 |
 | 0.4 | [0.4](plugins/nabledge-6/CHANGELOG.md#04---2026-03-04) | - | - | 2026-03-04 |

--- a/.claude/skills/nabledge-5/plugin/CHANGELOG.md
+++ b/.claude/skills/nabledge-5/plugin/CHANGELOG.md
@@ -4,10 +4,16 @@ nabledge-5プラグインの主な変更内容を記録しています。
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) に基づいています。
 
+## [0.2] - 2026-03-27
+
+### 追加
+- インストールガイドにトラブルシューティングセクションを追加しました。プロキシ環境や権限不足によるインストール失敗時の対処方法を確認できます。
+
 ## [0.1] - 2026-03-13
 
 ### 追加
 
 - Nablarch 5の全ドキュメントをカバーする知識ファイルを追加しました。
 
+[0.2]: https://github.com/nablarch/nabledge/releases/tag/0.7
 [0.1]: https://github.com/nablarch/nabledge/releases/tag/0.6

--- a/.claude/skills/nabledge-5/plugin/plugin.json
+++ b/.claude/skills/nabledge-5/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nabledge-5",
-  "version": "0.1",
+  "version": "0.2",
   "description": "Nablarch 5 skill for AI-assisted development",
   "author": {
     "name": "Nablarch"


### PR DESCRIPTION
## Summary

- Closes #257
- Adds `[0.2] - 2026-03-27` section to nabledge-5 CHANGELOG reflecting the troubleshooting guide addition from PR #256
- Bumps `plugin.json` to version `0.2` for nabledge-5
- Updates marketplace CHANGELOG v0.7 row to list nabledge-5 at `[0.2]`

## Approach

nabledge-5 v0.2 release metadata update. The troubleshooting guide addition (PR #256) was missing version metadata. This adds `[0.2] - 2026-03-27` to nabledge-5 CHANGELOG, bumps `plugin.json` to `0.2`, and updates the marketplace v0.7 row to reflect nabledge-5 at 0.2.

## Tasks

- [x] `.claude/skills/nabledge-5/plugin/CHANGELOG.md` — `[0.2] - 2026-03-27` section with troubleshooting entry
- [x] `.claude/skills/nabledge-5/plugin/plugin.json` — version `0.2`
- [x] `.claude/marketplace/CHANGELOG.md` — 0.7 row updated to nabledge-5 `[0.2]`

## Expert Review

No expert review (release metadata fix only)

## Success Criteria

- [x] `.claude/skills/nabledge-5/plugin/CHANGELOG.md` — `[0.2] - 2026-03-27` section with troubleshooting entry
- [x] `.claude/skills/nabledge-5/plugin/plugin.json` — version `0.2`
- [x] `.claude/marketplace/CHANGELOG.md` — 0.7 row updated to nabledge-5 `[0.2]`