### PR TITLE
docs: show hyphen for unchanged plugins in marketplace CHANGELOG (#356)

### DIFF
--- a/.claude/marketplace/CHANGELOG.md
+++ b/.claude/marketplace/CHANGELOG.md
@@ -9,7 +9,7 @@ Nabledgeマーケットプレイス全体のバージョン対応表です。
 | マーケットプレイスバージョン | nabledge-6 | nabledge-5 | nabledge-1.4 | nabledge-1.3 | nabledge-1.2 | リリース日 |
 |---------------------------|-----------|-----------|-------------|-------------|-------------|----------|
 | 0.9 | [0.8](plugins/nabledge-6/CHANGELOG.md#08---2026-05-26) | [0.3](plugins/nabledge-5/CHANGELOG.md#03---2026-05-26) | [0.2](plugins/nabledge-1.4/CHANGELOG.md#02---2026-05-26) | [0.2](plugins/nabledge-1.3/CHANGELOG.md#02---2026-05-26) | [0.2](plugins/nabledge-1.2/CHANGELOG.md#02---2026-05-26) | 2026-05-26 |
-| 0.8 | [0.7](plugins/nabledge-6/CHANGELOG.md#07---2026-03-27) | [0.2](plugins/nabledge-5/CHANGELOG.md#02---2026-03-27) | [0.1](plugins/nabledge-1.4/CHANGELOG.md#01---2026-03-27) | [0.1](plugins/nabledge-1.3/CHANGELOG.md#01---2026-03-30) | [0.1](plugins/nabledge-1.2/CHANGELOG.md#01---2026-03-30) | 2026-03-30 |
+| 0.8 | - | - | - | [0.1](plugins/nabledge-1.3/CHANGELOG.md#01---2026-03-30) | [0.1](plugins/nabledge-1.2/CHANGELOG.md#01---2026-03-30) | 2026-03-30 |
 | 0.7 | [0.7](plugins/nabledge-6/CHANGELOG.md#07---2026-03-27) | [0.2](plugins/nabledge-5/CHANGELOG.md#02---2026-03-27) | [0.1](plugins/nabledge-1.4/CHANGELOG.md#01---2026-03-27) | - | - | 2026-03-27 |
 | 0.6 | [0.6](plugins/nabledge-6/CHANGELOG.md#06---2026-03-13) | [0.1](plugins/nabledge-5/CHANGELOG.md#01---2026-03-13) | - | - | - | 2026-03-13 |
 | 0.5 | [0.5](plugins/nabledge-6/CHANGELOG.md#05---2026-03-10) | - | - | - | - | 2026-03-10 |


### PR DESCRIPTION
Closes #356

## Approach

In the version table, cells that show a plugin version already released in a prior row were misleading — they implied activity where there was none. Changed those cells to `-` so only rows where a plugin version was newly released show a linked version number.

Specifically, marketplace 0.8 row: nabledge-6/5/1.4 had no changes (all released in 0.7) → changed to `-`. nabledge-1.3/1.2 were first released in 0.8 → kept as-is.

## Tasks

No tasks.md — single-file documentation fix.

## Expert Review

No expert review — mechanical one-cell table correction with no design judgment involved.

## Success Criteria Check

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Cells show `-` when plugin had no changes in that release | ✅ Met | 0.8 row: nabledge-6/5/1.4 changed to `-` |
| Cells show linked version only when plugin version changed | ✅ Met | 0.8 row retains nabledge-1.3/1.2 links (first release) |
| nabledge-dev `marketplace/CHANGELOG.md` updated | ✅ Met | `.claude/marketplace/CHANGELOG.md` |
| nablarch/nabledge `CHANGELOG.md` updated | ❌ Not Met | Synced automatically on merge to main |

🤖 Generated with [Claude Code](https://claude.com/claude-code)