### PR TITLE
docs: tighten Success Criteria rule to require observable outcomes

### DIFF
--- a/.claude/rules/issues.md
+++ b/.claude/rules/issues.md
@@ -18,8 +18,9 @@ Who is affected and what problem do they face?
 Who benefits and how? Use "[who] can [what]" format.
 
 ### Success Criteria
-- [ ] Verifiable outcomes as checkboxes
-- [ ] Each criterion directly relates to stated benefits
+- [ ] Write each criterion as an observable outcome — something any stakeholder can verify without knowing the implementation
+- [ ] Quantify where possible (benchmark scores, pass rates, counts)
+- [ ] Do not include means, file paths, or implementation details
 
 ## Bug-Specific Success Criteria
 
@@ -89,6 +90,5 @@ Reviewers reconstruct context from commits. Developers lack clear documentation 
 - Maintainers can enforce quality standards
 
 ### Success Criteria
-- [ ] `.claude/skills/pr/workflows/create.md` includes PR template
-- [ ] Template covers Approach, Tasks, Review, Success Criteria
-- [ ] New PRs reference issue numbers and verify criteria
+- [ ] A PR created via `/hi` can be reviewed by the user without asking the author for additional context
+- [ ] PRs created before and after adopting the new format are indistinguishable in structure by a reviewer


### PR DESCRIPTION
## Approach

Success Criteria の書き方ルールを強化。従来の「Verifiable outcomes」「directly relates to stated benefits」では手段・ファイルパス・実装詳細がフィルタをすり抜けていた。

新ルールは「any stakeholder can verify without knowing the implementation」という判定基準を明示することで、実装詳細を構造的に排除する。また定量化を推奨し、例のSCも observable outcomes に書き直した。

## Tasks

変更は単一コミット。tasks.md なし。

## Expert Review

なし（ルールドキュメントの小規模修正）。

## Success Criteria Check

| Criterion | Status | Evidence |
|-----------|--------|----------|
| SCルールに「実装詳細を含めない」判定基準が明示されている | ✅ Met | `.claude/rules/issues.md` — "without knowing the implementation" |
| 例のSCが observable outcomes になっている | ✅ Met | ファイルパス・仕様項目 → ユーザー観察可能な状態に書き直し |

🤖 Generated with [Claude Code](https://claude.com/claude-code)