### PR TITLE
docs: fix design docs out of sync with implementation (#380)

### DIFF
--- a/docs/benchmark-design.md
+++ b/docs/benchmark-design.md
@@ -53,7 +53,7 @@ tools/benchmark/
       "when": {
         "workflow": "qa",
         "input": "質問テキスト",
-        "expected_hearing": "should_skip | should_ask",
+        "expected_hearing": "should_skip | must_ask | nice_to_ask",
         "hearing_answer": {
           "processing_type": "処理方式名 | null",
           "purpose": "目的名"
@@ -79,7 +79,7 @@ tools/benchmark/
 | `id` | シナリオID（例: `pre-01`, `qa-01`, `impact-01`） |
 | `phase` | フェーズ（`pre-benchmark`, `benchmark`, `impact`） |
 | `when.input` | ユーザーの質問テキスト |
-| `when.expected_hearing` | ヒアリングが発生するか（`should_skip`: スキップ予想、`should_ask`: 発生予想） |
+| `when.expected_hearing` | ヒアリングの期待値（`should_skip`: スキップ予想、`must_ask`: ヒアリング必須、`nice_to_ask`: ヒアリングが望ましいが任意） |
 | `when.hearing_answer` | ランナーがStep 1/2をスキップしてStep 3から開始するための事前設定値 |
 | `then.must` | 回答に必ず含まれるべき事実のリスト（`section` はDeepEvalが `retrieval_context` を構築する際に参照するナレッジセクション） |
 | `then.acceptable` | あってもよいセクションのリスト（評価には不使用） |
@@ -162,7 +162,7 @@ summary.json 保存
 | `evaluation.json` | 正常完了時 | 自動評価結果 |
 | `error.json` | エラー時のみ | エラー内容（`error`, `exception_type`） |
 | `raw_response.txt` | MarkerError時のみ | パース失敗したレスポンス全文 |
-| `summary.json` | 実行完了時 | 全シナリオのサマリー（`total_scenarios`, `skill_dir`, `scenarios_file`, `executed_at`） |
+| `summary.json` | 実行完了時 | 全シナリオのサマリー（`total_scenarios`, `skill_dir`, `scenarios_file`, `executed_at`, `scenarios`） |
 
 ---
 
@@ -277,6 +277,8 @@ report.py でレポート生成（閾値割れシナリオを一覧）
 |---|---|
 | フルレポート（1実行） | `{run-dir}/report.md` |
 | 比較レポート | `{run-dir}/comparison-{label_b}.md` |
+| 退行チェックレポート | `{run-dir}/regression-check.md` |
+| 3run横断集約レポート | `{crossrun-dir}/crossrun-summary.md` |
 
 ---
 

--- a/docs/nabledge-design.md
+++ b/docs/nabledge-design.md
@@ -87,7 +87,7 @@ Nabledgeは3つの要素で構成されます。
 
 1. **知識基盤**
 
-   構造化されたNablarch知識（TOON形式インデックス、JSON形式知識ファイル）
+   構造化されたNablarch知識（Markdown形式インデックス、JSON形式知識ファイル）
 
 2. **ワークフロー**
 
@@ -112,14 +112,14 @@ graph TB
         direction TB
 
         subgraph workflows["🤖 ワークフロー（LLM実行）"]
-            WF_SEARCH["知識検索<br/>(keyword-search)<br/>関連度判定"]
+            WF_SEARCH["知識検索<br/>(semantic-search/keyword-search)<br/>関連度判定"]
             WF_DELEGATE["代行作業<br/>実装調査・コード生成・レビュー"]
             WF_GENERATE["知識ファイル生成・検証<br/>3分/ファイル・20%サンプリング"]
         end
 
         subgraph knowledge["知識基盤"]
-            INDEX["インデックス(TOON)<br/>93エントリ・650検索ヒント"]
-            JSON["知識ファイル(JSON)<br/>60ファイル・420Kトークン"]
+            INDEX["インデックス(Markdown)<br/>index.md + classes.md"]
+            JSON["知識ファイル(JSON)<br/>353ファイル以上"]
             MD["知識ファイル(Markdown)<br/>人間確認用・根拠追跡"]
         end
     end
@@ -176,15 +176,15 @@ graph TB
 
 2. **知識検索**
 
-   AIツールがワークフロー（知識検索）を実行し、keyword-searchで検索します
+   AIツールがワークフロー（知識検索）を実行し、semantic-searchおよびkeyword-searchで検索します
 
 3. **セクション特定**
 
-   関連度の高いセクションを特定します（High/Partial/Noneの3段階）
+   関連度の高いセクションを特定します（high/partialの2段階）
 
 4. **代行作業実行**
 
-   ワークフロー（代行作業）を実行し、知識ファイルを参照します（上位10セクション ≈ 5,000トークン）
+   ワークフロー（代行作業）を実行し、知識ファイルを参照します（上位20セクション）
 
 5. **結果返却**
 
@@ -198,11 +198,11 @@ graph TB
 
 - **検索**
 
-  3段階キーワード抽出 + 2段階検索プロセス（ファイル→セクション）で高精度を実現
+  index.md（本文索引）+ classes.md（クラス名索引）の2経路でページを選定し、セクション単位で関連度判定
 
 - **トークン効率**
 
-  TOON形式で30-60%削減、セクション単位抽出で必要最小限（5,000トークン）に抑制
+  セクション単位抽出で必要最小限に抑制
 
 - **正確性**
 
@@ -279,19 +279,26 @@ Claude Codeの標準配布方式を採用します。GitHubからの自動取得
 nabledge-6/
 ├── SKILL.md                    # スキル定義
 ├── knowledge/                  # 知識
-│   ├── index.toon              # 検索インデックス（TOON形式）
-│   ├── features/               # ① 機能・実装パターン
+│   ├── index.md                # 意味検索インデックス（Markdown形式）
+│   ├── classes.md              # クラス名ベース検索インデックス
+│   ├── component/              # コンポーネント（ハンドラ・ライブラリ・アダプタ等）
 │   │   ├── handlers/           # ハンドラ単位
 │   │   ├── libraries/          # ライブラリ単位
-│   │   ├── processing/         # 処理方式単位
-│   │   ├── tools/              # ツール単位
 │   │   └── adapters/           # アダプタ単位
-│   ├── checks/                 # ② チェック項目
-│   └── releases/               # ③ リリースノート
+│   ├── processing-pattern/     # 処理方式別実装パターン
+│   ├── development-tools/      # 開発ツール
+│   ├── check/                  # チェック項目
+│   ├── about/                  # Nablarch概要・移行・リリースノート
+│   ├── releases/               # リリースノート
+│   ├── javadoc/                # Javadoc
+│   ├── setup/                  # セットアップ
+│   ├── assets/                 # アセット
+│   └── guide/                  # ガイド
 ├── workflows/                  # ワークフロー（代行単位）
 ├── scripts/                    # スクリプト
 ├── assets/                     # アセット
-└── docs/                       # 人向け閲覧用（JSON→MD自動変換）
+├── docs/                       # 人向け閲覧用（JSON→MD自動変換）
+└── plugin/                     # マーケットプレイス配布用メタデータ・CHANGELOG
 ```
 
 **命名規則**
@@ -304,149 +311,41 @@ nabledge-6/
 
 ### 2.5 検索設計
 
-Nabledgeの検索は、ユーザーの依頼から必要な知識を高精度で特定する仕組みです。3段階のキーワード抽出と、2段階の検索プロセス（ファイル選定→セクション選定）で実現します。
+Nabledgeの検索は、ユーザーの依頼から必要な知識を高精度で特定する仕組みです。詳細は `docs/search-design.md` を参照してください。
 
 #### 検索の全体フロー
 
 ```
 ユーザー依頼（例：「ページングを実装したい」）
   ↓
-① 3段階キーワード抽出
+① 質問分類（処理方式・目的の確定）
   ↓
-② ファイル選定（index.toonで検索）
+② 意味検索（semantic-search.md）
+    Phase A: index.md でページ候補選定
+    Phase B: classes.md でクラス名ベース補完選定
+    Phase C: マージ・重複除去（最大20ページ）
+    Phase D: セクション選定（最大20件）
+    Phase E: Javadoc付加（最大10件）
   ↓
-③ セクション選定（ファイル内indexで検索）
+③ セクション内容の読み取り（最大20件）
   ↓
-④ 関連度判定（High/Partial/None）
-  ↓
-⑤ 検索結果構造化（pointers）
-  ↓
-⑥ コンテキスト管理（上位N件抽出）
+④ 回答生成・ハルシネーション検証
 ```
 
-#### ① 3段階キーワード抽出
+#### インデックス構造
 
-ユーザーの依頼から、以下の3段階でキーワードを抽出します。
+**`knowledge/index.md`**: カテゴリ（H2）→ページ（H3）→セクション（箇条書き）の階層Markdown。意味検索 Phase A のページ選定に使用。
 
-| レベル | 名称 | 説明 | 例 |
-|:-----:|------|------|-----|
-| Level 1 | Technical domain（技術領域） | データベース, バッチ, ハンドラ, Web, REST, テスト など | データベース, database |
-| Level 2 | Technical component（技術要素） | DAO, JDBC, JPA, Bean Validation, JSON, XML など | DAO, UniversalDao, O/Rマッパー |
-| Level 3 | Functional（機能） | ページング, 検索, 登録, 更新, 削除, 接続, コミット など | ページング, paging, per, page, limit, offset |
+**`knowledge/classes.md`**: ページタイトル（H3）+ `path:` 行 + クラス名リスト（`- ClassName`）の形式。意味検索 Phase B のクラス名ベース補完に使用。
 
-**例**
+#### 関連度判定
 
-依頼「ページングを実装したい」→ Level 1「データベース」、Level 2「DAO」、Level 3「ページング」に分解
+セクション単位で high / partial の2段階で判定:
 
-#### ② ファイル選定（index.toon）
-
-**使用するキーワード**
-
-Level 1（技術領域）+ Level 2（技術要素）
-
-**index.toonの構造**:
-```toon
-# Nabledge-6 Knowledge Index
-
-files[N,]{path,hints}:
-  features/handlers/common/global-error-handler.json, グローバルエラーハンドラ GlobalErrorHandler 未捕捉例外 エラーハンドリング 例外処理
-  features/libraries/universal-dao.json, ユニバーサルDAO UniversalDao CRUD 検索 ページング データベース DAO
-```
-
-- TOON形式でJSONより30-60%トークン削減
-- 93エントリ、約650検索ヒント → 約5-7Kトークン
-- 各ファイルのパスと検索ヒント（Level 1 + Level 2）を記載
-
-**マッチング例**
-
-「データベース」「DAO」で `universal-dao.json` が候補に
-
-#### ③ セクション選定（ファイル内index）
-
-**使用するキーワード**
-
-Level 2（技術要素）+ Level 3（機能）
-
-**ファイル内indexの構造**:
-```json
-{
-  "index": [
-    { "id": "overview", "hints": ["UniversalDao", "ユニバーサルDAO"] },
-    { "id": "paging", "hints": ["ページング", "paging", "per", "page", "limit", "offset"] },
-    { "id": "search", "hints": ["検索", "search", "条件指定"] }
-  ]
-}
-```
-
-- 各セクションの検索ヒント（Level 2 + Level 3）を記載
-- セクション単位で関連度を判定
-
-**マッチング例**
-
-「ページング」「paging」で `paging` セクションが候補に
-
-#### ④ 関連度判定
-
-候補となったセクションの実際の内容を読み、ユーザーの依頼に対する関連度を判定します。
-
-| レベル | 値 | 判断基準 |
-|:------:|:---:|---------|
-| **High** | 2 | 依頼に直接回答できる |
-| **Partial** | 1 | 依頼に関連し、補足として有用 |
-| **None** | 0 | 関連なし（対象外） |
-
-**ファイルの関連度**
-
-そのファイル内のセクション関連度の最大値
-
-**例**: `universal-dao.json`
-- `paging` セクション: High (2)
-- `search` セクション: Partial (1)
-- `overview` セクション: Partial (1)
-→ ファイルの関連度 = 2 (最大値)
-
-#### ⑤ 検索結果構造化（pointers）
-
-検索結果をpointers構造で返します。
-
-```json
-{
-  "files": [
-    { "id": "F1", "path": "features/libraries/universal-dao.json", "relevance": 2, "matched_hints": ["データベース", "DAO"] }
-  ],
-  "sections": [
-    { "file_id": "F1", "section": "paging", "relevance": 2, "matched_hints": ["ページング", "paging", "per", "page"] },
-    { "file_id": "F1", "section": "search", "relevance": 1, "matched_hints": ["検索"] }
-  ]
-}
-```
-
-**構造の特徴**:
-- `sections` を関連度降順でソート → 最重要セクションから読める
-- `files` でファイル単位の重要度を把握
-- ファイルパスは1回だけ出現、`file_id` で参照（重複排除）
-- `matched_hints` で判断根拠を追跡可能
-
-#### ⑥ コンテキスト管理（上位N件抽出）
-
-関連度の高いセクションを抽出します。
-
-| 項目 | 推奨値 | 根拠 |
-|------|--------|------|
-| sections | 上位10件 | 1セクション平均500トークン × 10 = 約5,000トークン（コンテキストの2.5%） |
-
-**動的調整**:
-- High（2点）のセクションが10件未満 → Partial（1点）も含めて最大15件まで拡張
-- High（2点）のセクションが20件以上 → 上位15件まで拡張
-- コンテキスト使用率が80%超 → セクション数を減らす（最小5件）
-
-**設計判断**:
-- セクション単位で抽出することで、ファイル全体（約7,000トークン）ではなく必要最小限（約500トークン）に抑えます
-- 全60ファイル（約420,000トークン）をコンテキストウィンドウ（200,000トークン）内で運用可能にします
-
-#### 将来の拡張
-
-現状、keyword-searchだけで十分な検索精度が得られています。将来的に検索精度の向上が必要になった場合は、intent-search（目的→カテゴリ、対象→ファイルで絞り込む方式）の導入を検討します。
+| レベル | 判断基準 |
+|:------:|---------|
+| **high** | このセクションなしに質問への完全な回答は不可能 |
+| **partial** | high セクションを使う際に必要な背景や設定を提供しており、high だけからは推測できない |
 
 ### 2.6 知識ファイル設計
 
@@ -456,22 +355,22 @@ Level 2（技術要素）+ Level 3（機能）
 
 ```json
 {
-  "schema_version": "1.0",
-  "id": "ファイル識別子",
+  "id": "ファイル識別子（カテゴリパスなし）",
   "title": "タイトル（日本語）",
-  "official_doc_urls": ["https://nablarch.github.io/docs/..."],
-  "index": [
-    { "id": "セクションID", "hints": ["検索ヒント1", "検索ヒント2"] }
-  ],
-  "sections": {
-    "overview": {
-      "summary": "100-200文字の要約",
-      /* セクション固有のプロパティ */
-    },
-    "セクションID": { /* ... */ }
-  }
+  "content": "ページ導入文（セクション開始前のトップレベル内容）",
+  "no_knowledge_content": false,
+  "sections": [
+    {
+      "id": "sN",
+      "title": "セクションタイトル",
+      "content": "セクション本文",
+      "level": 2
+    }
+  ]
 }
 ```
+
+詳細なスキーマ定義は `tools/rbkc/docs/rbkc-json-schema-design.md` を参照してください。
 
 **設計判断**
 

--- a/tools/benchmark/scripts/run_qa.py
+++ b/tools/benchmark/scripts/run_qa.py
@@ -4,13 +4,12 @@ Runs the qa.md workflow for each scenario, capturing diagnostic markers from
 the response to extract hearing, search, and answer information.
 
 Output per scenario:
-  {output-dir}/{scenario-id}/hearing.json    — hearing behavior (skipped or asked)
-  {output-dir}/{scenario-id}/search.json     — search results (section IDs)
-  {output-dir}/{scenario-id}/answer.md       — generated answer text
-  {output-dir}/{scenario-id}/metrics.json    — performance metrics
-  {output-dir}/{scenario-id}/trace.json      — full claude -p JSON output (for QA review)
-  {output-dir}/{scenario-id}/evaluation.json — evaluation results
-  {output-dir}/summary.json                  — run summary with context
+  {output-dir}/{scenario-id}/workflow_details.json — step3/step4/step8 details (pages, sections, answer sections)
+  {output-dir}/{scenario-id}/answer.md             — generated answer text
+  {output-dir}/{scenario-id}/metrics.json          — performance metrics
+  {output-dir}/{scenario-id}/trace.json            — full claude -p JSON output (for QA review)
+  {output-dir}/{scenario-id}/evaluation.json       — evaluation results
+  {output-dir}/summary.json                        — run summary with context
 """
 from __future__ import annotations
 

--- a/tools/rbkc/docs/rbkc-converter-design.md
+++ b/tools/rbkc/docs/rbkc-converter-design.md
@@ -29,13 +29,30 @@
 ```
 tools/rbkc/scripts/
 ├── common/         ← create と verify が共有する純粋ロジック層
-│   ├── rst_ast.py      ← docutils パーサ設定・AST ユーティリティ
-│   ├── md_ast.py       ← markdown-it-py パーサ設定
-│   ├── labels.py       ← RST ラベル解決 (LabelTarget)
-│   └── github_slug.py  ← GitHub heading anchor 生成
+│   ├── rst_ast.py          ← docutils パーサ設定・AST ユーティリティ
+│   ├── rst_ast_visitor.py  ← RST AST Visitor 基底クラス
+│   ├── rst_normaliser.py   ← RST → 正規化 MD 変換
+│   ├── rst_admonition.py   ← RST admonition ノード処理
+│   ├── md_ast.py           ← markdown-it-py パーサ設定
+│   ├── md_ast_visitor.py   ← MD AST Visitor 基底クラス
+│   ├── md_normaliser.py    ← MD → 正規化 MD 変換
+│   ├── labels.py           ← RST ラベル解決 (LabelTarget)
+│   ├── github_slug.py      ← GitHub heading anchor 生成
+│   ├── linkfmt.py          ← リンク形式変換
+│   ├── file_id.py          ← ファイル識別子生成
+│   ├── handler_js.py       ← ハンドラJS処理
+│   ├── javadoc_fqcn.py     ← Javadoc 完全修飾クラス名処理
+│   └── sources.py          ← ソースファイル管理
 ├── create/         ← 変換実装（verify からのインポート禁止）
 │   ├── converters/ ← フォーマット別 AST → RSTResult 変換
-│   └── docs.py     ← RSTResult → docs MD 生成
+│   ├── classes.py  ← classes.md 生成
+│   ├── classify.py ← ファイル分類
+│   ├── differ.py   ← 差分検出
+│   ├── docs.py     ← RSTResult → docs MD 生成
+│   ├── index.py    ← index.md 生成
+│   ├── javadoc.py  ← Javadoc 変換
+│   ├── resolver.py ← 参照解決
+│   └── scan.py     ← ソーススキャン
 └── verify/         ← 検証実装（create からのインポート禁止）
     └── verify.py   ← JSON / docs MD / index.md の品質チェック
 ```

--- a/tools/rbkc/docs/rbkc-verify-quality-design.md
+++ b/tools/rbkc/docs/rbkc-verify-quality-design.md
@@ -34,7 +34,7 @@ verify は品質観点を ID で管理する。ID の形式：
 - **RBKC mapping**: `docs/mapping/` 配下にある「どのソースファイルをどの知識ファイル（JSON）に変換するか」を定義したマッピングファイル群。mapping に「採用」されていないソースファイルは RBKC の変換対象外となる。QL1 の dangling reference 判定で「そのファイルが変換対象か否か」を判断するために参照する（§3-2-2 の象限分類参照）。
 - **corpus**: RBKC が対象とするソースファイル全体（`.lw/nab-official/` 配下の RST / MD / Excel）。「corpus 全量」は全ファイルを指す。
 - **Phase**: RBKC 開発の機能追加フェーズを識別するラベル（例: Phase 22-B-16）。「Phase XX の変更点」とあれば、その機能が追加された開発ラウンドを指す。仕様変更の経緯を追う際に参照するが、現在の仕様そのものは本書の本文に記載されている。
-- **tokenizer / 正規化ソース**: verify が QC1–QC4 を検証する際に使うテキスト処理。ソース（RST/MD）を公式パーサで AST 化し、Visitor で Markdown 等価形式に変換した文字列を「正規化ソース」と呼ぶ。この正規化ソースから JSON のトークンを順番に削除（sequential-delete）することで欠落・捏造・重複・配置ミスを検出する。「tokenizer」はこの正規化処理を行う部品を指す（`scripts/common/rst_normaliser.py` / `scripts/common/md_ast.py`）。詳細は §3-1 の STS 参照。
+- **tokenizer / 正規化ソース**: verify が QC1–QC4 を検証する際に使うテキスト処理。ソース（RST/MD）を公式パーサで AST 化し、Visitor で Markdown 等価形式に変換した文字列を「正規化ソース」と呼ぶ。この正規化ソースから JSON のトークンを順番に削除（sequential-delete）することで欠落・捏造・重複・配置ミスを検出する。「tokenizer」はこの正規化処理を行う部品を指す（`scripts/common/rst_normaliser.py` / `scripts/common/md_normaliser.py`）。詳細は §3-1 の STS 参照。
 
 ---
 

--- a/tools/rbkc/docs/xlsx-sheet-mapping.md
+++ b/tools/rbkc/docs/xlsx-sheet-mapping.md
@@ -8,7 +8,7 @@
 |---------|-------|-------------|
 | P1 | 93 | Header detected → structured sections (existing behavior, no change) |
 | P1-merged | 2 | P1 with title-column merged rows → group rows by merge range into one section per vulnerability |
-| P2-1 | 16 | Column-indent → Markdown headings (col0=H1, col1=H2, col2=H3, col3+=body) |
+| P2-1 | 16 | Column-indent → Markdown headings (col0=H2, col1=H3, col2=H4, col3+=body) |
 | P2-2 | 96 | Current behavior maintained (step tables, single-col lists, etc.) |
 | P2-3 | 3 | Embedded LF preserved as Markdown line breaks (`  \n`) |
 | P2-4 | 2 | 2-col table with preamble: preamble as plain text, data as Markdown table (LF→`<br>`) |


### PR DESCRIPTION
Closes #380

## Approach

Multiple design documents had drifted from the actual implementation over time. The fix audited each document against the current codebase and updated only the incorrect portions — no design changes, only accuracy corrections.

Key fixes made:
- `docs/nabledge-design.md`: Updated knowledge/ directory structure (component/, check/, processing-pattern/, javadoc/ etc.), corrected JSON schema fields (sections[] with id/title/content/level, content field), and replaced the obsolete TOON/3-stage keyword-search description with the current semantic-search Phase A/B/C/D/E design
- `docs/benchmark-design.md`: Added `must_ask`/`nice_to_ask` values for `expected_hearing`, added `scenarios` field to summary.json, and added `regression-check.md`/`crossrun-summary.md` to report output table
- `tools/benchmark/scripts/run_qa.py` docstring: Replaced `hearing.json`/`search.json` with `workflow_details.json`
- `tools/rbkc/docs/rbkc-converter-design.md`: Expanded common/ and create/ directory listings to reflect actual files (rst_normaliser.py, md_normaliser.py, classes.py, etc.)
- `tools/rbkc/docs/rbkc-verify-quality-design.md`: Fixed tokenizer reference md_ast.py → md_normaliser.py
- `tools/rbkc/docs/xlsx-sheet-mapping.md`: Corrected P2-1 col0 heading level H1 → H2

## Tasks

No tasks.md — this is a docs-only fix with no implementation tasks beyond the corrections themselves.

## Expert Review

Not conducted (docs-only change — no source code or prompt logic modified).

## Success Criteria Check

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `docs/nabledge-design.md`: knowledge/ directory names, index.md (not index.toon), JSON schema fields corrected | ✅ Met | Updated §2.4 directory structure, §2.5 search design, §2.6 JSON schema fields in docs/nabledge-design.md |
| `docs/benchmark-design.md`: `expected_hearing` value fixed (should_ask → must_ask), summary.json fields, report output table updated | ✅ Met | Added must_ask/nice_to_ask, scenarios field, regression-check.md and crossrun-summary.md in docs/benchmark-design.md |
| `tools/rbkc/docs/rbkc-converter-design.md`: directory listing updated with actual files | ✅ Met | Expanded common/ and create/ listings in rbkc-converter-design.md |
| `tools/rbkc/docs/rbkc-verify-quality-design.md`: md_ast.py → md_normaliser.py fixed | ✅ Met | Single-line fix in rbkc-verify-quality-design.md |
| `tools/rbkc/docs/xlsx-sheet-mapping.md`: P2-1 col0 heading level corrected | ✅ Met | Fixed H1 → H2 in xlsx-sheet-mapping.md |
| `run_qa.py` docstring (hearing.json/search.json) corrected | ✅ Met | Replaced with workflow_details.json in run_qa.py docstring |

🤖 Generated with [Claude Code](https://claude.com/claude-code)